### PR TITLE
Migrate embedded graphs from Catlab

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia_version: ['1.5']
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia_version }}
+      - name: "Build package"
+        uses: julia-actions/julia-buildpkg@v1
+      - name: "Run tests"
+        uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,12 @@
+name = "CombinatorialSpaces"
+uuid = "b1c52339-7909-45ad-8b6a-6e388f7c67f2"
+license = "MIT"
+authors = ["Evan Patterson <evan@epatters.org>"]
+version = "0.1.0"
+
+[deps]
+Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Catlab = "^0.10"

--- a/src/CombinatorialMaps.jl
+++ b/src/CombinatorialMaps.jl
@@ -1,0 +1,127 @@
+""" Combinatorial maps and related structures, as C-sets.
+
+In topological graph theory and graph drawing, an **embedded graph** is a
+combinatorial structure representing a graph embedded in an (oriented) surface,
+up to equivalence under (orientation-preserving) homeomorphism. This module
+defines data structures for rotation systems, combinatorial maps, and other
+combinatorial objects describing embedded graphs.
+"""
+module CombinatorialMaps
+export σ, α, ϕ, trace_vertices, trace_edges, trace_faces,
+  AbstractRotationGraph, RotationGraph, add_corolla!, pair_half_edges!,
+  AbstractRotationSystem, RotationSystem,
+  AbstractCombinatorialMap, CombinatorialMap
+
+using Catlab, Catlab.CategoricalAlgebra.CSets, Catlab.Graphs
+using Catlab.Graphs.BasicGraphs: TheoryHalfEdgeGraph
+using Catlab.Permutations: cycles
+
+# General properties
+####################
+
+""" Vertex permutation of combinatorial map or similar structure.
+"""
+σ(x::AbstractACSet, args...) = subpart(x, args..., :σ)
+
+""" Edge permutation of combinatorial map or similar structure.
+"""
+α(x::AbstractACSet, args...) = subpart(x, args..., :α)
+
+""" Face permutation of combinatorial map or similar structure.
+"""
+ϕ(x::AbstractACSet, args...) = subpart(x, args..., :ϕ)
+
+""" Trace vertices of combinatorial map or similar, returning a list of cycles.
+"""
+trace_vertices(x::AbstractACSet) = cycles(σ(x))
+
+""" Trace edges of combinatorial map or similar, return a listing of cycles.
+
+Usually the cycles will be pairs of half edges but in a hypermap the cycles can
+be arbitrary.
+"""
+trace_edges(x::AbstractACSet) = cycles(α(x))
+
+""" Trace faces of combinatorial map or similar, returning list of cycles.
+"""
+trace_faces(x::AbstractACSet) = cycles(ϕ(x))
+
+# Rotation graphs
+#################
+
+@present TheoryRotationGraph <: TheoryHalfEdgeGraph begin
+  σ::Hom(H,H)
+
+  compose(σ, vertex) == vertex
+end
+
+const AbstractRotationGraph = AbstractACSetType(TheoryRotationGraph)
+const RotationGraph = CSetType(TheoryRotationGraph, index=[:vertex])
+
+α(g::AbstractRotationGraph) = inv(g)
+ϕ(g::AbstractRotationGraph) = sortperm(inv(g)[σ(g)]) # == (σ ⋅ inv)⁻¹
+
+""" Add corolla to rotation graph, rotation system, or similar structure.
+
+A *corolla* is a vertex together with its incident half-edges, the number of
+which is its *valence*. The rotation on the half-edges is the consecutive one
+induced by the half-edge part numbers.
+"""
+function add_corolla!(g::AbstractRotationGraph, valence::Int; kw...)
+  v = add_vertex!(g; kw...)
+  n = nparts(g, :H)
+  add_parts!(g, :H, valence; vertex=v, σ=circshift((n+1):(n+valence), -1))
+end
+
+""" Pair together half-edges into edges.
+"""
+pair_half_edges!(g::AbstractRotationGraph, h, h′) =
+  set_subpart!(g, [h; h′], :inv, [h′; h])
+
+# Rotation systems
+##################
+
+@present TheoryRotationSystem(FreeSchema) begin
+  H::Ob
+  σ::Hom(H,H)
+  α::Hom(H,H)
+
+  compose(α, α) == id(H)
+end
+
+const AbstractRotationSystem = AbstractACSetType(TheoryRotationSystem)
+const RotationSystem = CSetType(TheoryRotationSystem)
+
+# ϕ == (σ⋅α)⁻¹ == α⁻¹ ⋅ σ⁻¹
+ϕ(sys::AbstractRotationSystem) = sortperm(α(sys)[σ(sys)])
+
+function add_corolla!(sys::AbstractRotationSystem, valence::Int)
+  n = nparts(sys, :H)
+  add_parts!(sys, :H, valence; σ=circshift((n+1):(n+valence), -1))
+end
+
+pair_half_edges!(sys::AbstractRotationSystem, h, h′) =
+  set_subpart!(sys, [h; h′], :α, [h′; h])
+
+# Combinatorial maps
+####################
+
+@present TheoryHypermap(FreeSchema) begin
+  H::Ob
+  σ::Hom(H,H)
+  α::Hom(H,H)
+  ϕ::Hom(H,H)
+
+  compose(σ, α, ϕ) == id(H)
+end
+
+@present TheoryCombinatorialMap <: TheoryHypermap begin
+  compose(α, α) == id(H)
+end
+
+const AbstractCombinatorialMap = AbstractACSetType(TheoryCombinatorialMap)
+const CombinatorialMap = CSetType(TheoryCombinatorialMap)
+
+# TODO: What kind of interface should we have for maps and hypermaps?
+
+end

--- a/src/CombinatorialSpaces.jl
+++ b/src/CombinatorialSpaces.jl
@@ -1,0 +1,5 @@
+module CombinatorialSpaces
+
+include("CombinatorialMaps.jl")
+
+end

--- a/test/CombinatorialMaps.jl
+++ b/test/CombinatorialMaps.jl
@@ -1,0 +1,62 @@
+module TestCombinatorialMaps
+using Test
+
+using Catlab.Graphs.BasicGraphs
+using CombinatorialSpaces.CombinatorialMaps
+
+""" Wheel graph on `n` vertices with its unique planar embedding.
+"""
+function embedded_wheel_graph(T::Type, n::Int)
+  @assert n >= 4
+  n = n - 1 # Count using number of outer vertices.
+  g = T()
+  for i in 1:n # Outer corollas.
+    add_corolla!(g, 3)
+  end
+  add_corolla!(g, n) # Inner corolla.
+  pair_half_edges!(g, (3n+1):4n, reverse(2:3:3n)) # Inner <-> outer pairs.
+  pair_half_edges!(g, 3:3:3n, circshift(1:3:3n, -1)) # Outer <-> outer pairs.
+  return g
+end
+
+# Rotation graphs
+#################
+
+g = embedded_wheel_graph(RotationGraph, 5)
+@test nv(g) == 5
+@test length(half_edges(g)) == 16
+@test half_edges(g, 1) == [1,2,3]
+@test half_edges(g, 5) == [13,14,15,16]
+@test σ(g, [1,2,3]) == [2,3,1]
+@test σ(g, [13,14,15,16]) == [14,15,16,13]
+@test α(g) == inv(g)
+
+faces = trace_faces(g)
+sort!(faces, by=length)
+@test map(length, faces) == [3,3,3,3,4]
+
+outer_face_vs = sort(vertex(g, faces[end]))
+inner_faces_vs = Set(sort(vertex(g, face)) for face in faces[1:end-1])
+@test outer_face_vs == [1,2,3,4]
+@test inner_faces_vs == Set([[1,2,5], [2,3,5], [3,4,5], [1,4,5]])
+
+# Rotation systems
+##################
+
+sys = embedded_wheel_graph(RotationSystem, 5)
+
+vertices = trace_vertices(sys)
+@test length(vertices) == 5
+@test [1,2,3] in vertices
+@test [13,14,15,16] in vertices
+
+edges = trace_edges(sys)
+@test length(edges) == 8
+@test [3,4] in edges
+@test [1,12] in edges
+
+@test σ(sys) == σ(g)
+@test α(sys) == inv(g)
+@test trace_faces(sys) == trace_faces(g)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,5 @@
+using Test
+
+@testset "CombinatorialMaps" begin
+  include("CombinatorialMaps.jl")
+end


### PR DESCRIPTION
Data structures for rotation graphs and rotation systems, plus the very rudiments of combinatorial maps and hypermaps. Formerly known as `Catlab.Graphs.EmbeddedGraphs`.