### PR TITLE
Discrete exterior derivative in two dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 
 [deps]
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/src/ArrayUtils.jl
+++ b/src/ArrayUtils.jl
@@ -5,12 +5,15 @@ export enumeratenz, applynz, fromnz
 
 using SparseArrays
 
+# Data types
+############
+
 abstract type AbstractArrayBuilder{T,N} end
 
 struct ArrayBuilder{T,N,Arr<:AbstractArray{T,N}} <: AbstractArrayBuilder{T,N}
   array::Arr
 end
-add!(builder::ArrayBuilder, i, v) = builder.array[i] += v
+add!(builder::ArrayBuilder, v, inds...) = builder.array[inds...] += v
 take(builder::ArrayBuilder) = builder.array
 
 struct SparseVectorBuilder{Tv,Ti<:Integer} <: AbstractArrayBuilder{Tv,1}
@@ -18,22 +21,41 @@ struct SparseVectorBuilder{Tv,Ti<:Integer} <: AbstractArrayBuilder{Tv,1}
   I::Vector{Ti}
   V::Vector{Tv}
 end
-function add!(builder::SparseVectorBuilder, i::Integer, v)
+function add!(builder::SparseVectorBuilder, v, i::Integer)
   push!(builder.I, i); push!(builder.V, v)
 end
-function add!(builder::SparseVectorBuilder, i::AbstractVector, v)
+function add!(builder::SparseVectorBuilder, v, i::AbstractVector)
   append!(builder.I, i); append!(builder.V, v)
 end
 take(builder::SparseVectorBuilder) = sparsevec(builder.I, builder.V, builder.n)
+
+struct SparseMatrixBuilder{Tv,Ti<:Integer} <: AbstractArrayBuilder{Tv,2}
+  m::Int
+  n::Int
+  I::Vector{Ti}
+  J::Vector{Ti}
+  V::Vector{Tv}
+end
+function add!(builder::SparseMatrixBuilder, v, i::Integer, j::Integer)
+  push!(builder.I, i); push!(builder.J, j); push!(builder.V, v)
+end
+function add!(builder::SparseMatrixBuilder, v, i::AbstractVector, j::AbstractVector)
+  append!(builder.I, i); append!(builder.J, j); append!(builder.V, v)
+end
+take(builder::SparseMatrixBuilder) = sparse(builder.I, builder.J, builder.V,
+                                            builder.m, builder.n)
 
 """ Object for efficient incremental construction of dense or sparse vector.
 """
 nzbuilder(::Type{Arr}, dims::Integer...) where Arr =
   ArrayBuilder(zeros(Arr, dims))
-nzbuilder(::Type{SparseVector{Tv,Ti}}, n::Integer) where {Tv,Ti} =
-  SparseVectorBuilder(n, Ti[], Tv[])
-nzbuilder(::Type{SparseVector{Tv}}, n::Integer) where Tv =
+nzbuilder(::Type{<:SparseVector{Tv}}, n::Integer) where Tv =
   SparseVectorBuilder(n, Int[], Tv[])
+nzbuilder(::Type{<:SparseMatrixCSC{Tv}}, m::Integer, n::Integer) where {Tv,Ti} =
+  SparseMatrixBuilder(m, n, Int[], Int[], Tv[])
+
+# Functions
+###########
 
 """ Enumerate structural nonzeros of vector.
 """
@@ -43,13 +65,13 @@ enumeratenz(v::SparseVector) = zip(findnz(v)...)
 """ Apply linear map defined in terms of structural nonzero values.
 """
 function applynz(f, x::Vec, m::Integer, n::Integer) where Vec <: AbstractVector
-  length(x) == m ||
-    error("Vector length does not match domain: $(length(x)) != $m")
-  y = nzbuilder(Vec, n)
+  length(x) == n ||
+    error("Vector length does not match domain: $(length(x)) != $n")
+  y = nzbuilder(Vec, m)
   for (i, a) in enumeratenz(x)
     if !iszero(a)
       j, b = f(i)
-      add!(y, j, a*b)
+      add!(y, a*b, j)
     end
   end
   take(y)
@@ -57,6 +79,16 @@ end
 
 """ Construct array, not necessarily sparse, from structural nonzero values.
 """
+function fromnz(f, ::Type{Mat}, m::Integer, n::Integer) where Mat <: AbstractMatrix
+  A = nzbuilder(Mat, m, n)
+  for j in 1:n
+    for (i, a) in zip(f(j)...)
+      add!(A, a, i, j)
+    end
+  end
+  take(A)
+end
+
 function fromnz(::Type{Vec}, I::AbstractVector, V::AbstractVector,
                 n::Integer) where Vec <: AbstractVector
   vec = zeros(Vec, n)

--- a/src/ArrayUtils.jl
+++ b/src/ArrayUtils.jl
@@ -42,15 +42,17 @@ enumeratenz(v::SparseVector) = zip(findnz(v)...)
 
 """ Apply linear map defined in terms of structural nonzero values.
 """
-function applynz(f, u::Vec, n::Integer) where Vec <: AbstractVector
-  vec = nzbuilder(Vec, n)
-  for (i, c) in enumeratenz(u)
-    if !iszero(c)
-      j, x = f(i)
-      add!(vec, j, c*x)
+function applynz(f, x::Vec, m::Integer, n::Integer) where Vec <: AbstractVector
+  length(x) == m ||
+    error("Vector length does not match domain: $(length(x)) != $m")
+  y = nzbuilder(Vec, n)
+  for (i, a) in enumeratenz(x)
+    if !iszero(a)
+      j, b = f(i)
+      add!(y, j, a*b)
     end
   end
-  take(vec)
+  take(y)
 end
 
 """ Construct array, not necessarily sparse, from structural nonzero values.

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -100,11 +100,12 @@ const OrientedSimplicialSet1D = ACSetType(OrientedSimplexSchema1D,
 """
 edge_sign(s::AbstractACSet, args...) = @. 2 * s[args..., :edge_orientation] - 1
 
-∂₁(s::AbstractACSet, e::Int) = ∂₁(s, e, SparseVector{Int})
-∂₁(s::AbstractACSet, e::Int, ::Type{Vec}) where Vec <: AbstractVector =
+∂₁(s::AbstractACSet, e::Int, Vec::Type=SparseVector{Int}) =
   fromnz(Vec, ∂₁nz(s,e)..., nv(s))
 ∂₁(s::AbstractACSet, echain::AbstractVector) =
-  applynz(echain, ne(s), nv(s)) do e; ∂₁nz(s,e) end
+  applynz(echain, nv(s), ne(s)) do e; ∂₁nz(s,e) end
+∂₁(s::AbstractACSet, Mat::Type=SparseMatrixCSC{Int}) =
+  fromnz(Mat, nv(s), ne(s)) do e; ∂₁nz(s,e) end
 
 function ∂₁nz(s::AbstractACSet, e::Int)
   (SVector(∂₁(0,s,e), ∂₁(1,s,e)), edge_sign(s,e) * @SVector([1,-1]))
@@ -113,7 +114,9 @@ end
 """ Coboundary operator on 0-forms.
 """
 δ₀(s::AbstractACSet, vform::AbstractVector) =
-  applynz(vform, nv(s), ne(s)) do v; δ₀nz(s,v) end
+  applynz(vform, ne(s), nv(s)) do v; δ₀nz(s,v) end
+δ₀(s::AbstractACSet, Mat::Type=SparseMatrixCSC{Int}) =
+  fromnz(Mat, ne(s), nv(s)) do v; δ₀nz(s,v) end
 
 function δ₀nz(s::AbstractACSet, v::Int)
   e₀, e₁ = ∂₁_inv(0,s,v), ∂₁_inv(1,s,v)
@@ -248,11 +251,12 @@ const OrientedSimplicialSet2D = ACSetType(OrientedSimplexSchema2D,
 """
 triangle_sign(s::AbstractACSet, args...) = @. 2 * s[args..., :tri_orientation] - 1
 
-∂₂(s::AbstractACSet, t::Int) = ∂₂(s, t, SparseVector{Int})
-∂₂(s::AbstractACSet, t::Int, ::Type{Vec}) where Vec <: AbstractVector =
+∂₂(s::AbstractACSet, t::Int, Vec::Type=SparseVector{Int}) =
   fromnz(Vec, ∂₂nz(s,t)..., ne(s))
 ∂₂(s::AbstractACSet, tchain::AbstractVector) =
-  applynz(tchain, ntriangles(s), ne(s)) do t; ∂₂nz(s,t) end
+  applynz(tchain, ne(s), ntriangles(s)) do t; ∂₂nz(s,t) end
+∂₂(s::AbstractACSet, Mat::Type=SparseMatrixCSC{Int}) =
+  fromnz(Mat, ne(s), ntriangles(s)) do t; ∂₂nz(s,t) end
 
 function ∂₂nz(s::AbstractACSet, t::Int)
   edges = SVector(∂₂(0,s,t), ∂₂(1,s,t), ∂₂(2,s,t))
@@ -262,7 +266,9 @@ end
 """ Coboundary operator on 1-forms.
 """
 δ₁(s::AbstractACSet, eform::AbstractVector) =
-  applynz(eform, ne(s), ntriangles(s)) do e; δ₁nz(s,e) end
+  applynz(eform, ntriangles(s), ne(s)) do e; δ₁nz(s,e) end
+δ₁(s::AbstractACSet, Mat::Type=SparseMatrixCSC{Int}) =
+  fromnz(Mat, ntriangles(s), ne(s)) do e; δ₁nz(s,e) end
 
 function δ₁nz(s::AbstractACSet, e::Int)
   sgn = edge_sign(s, e)

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -50,6 +50,10 @@ vvec = ∂₁(s, sparsevec([1,-1,1]))
 @test issparse(vvec)
 @test vvec == [-1,0,0,1]
 
+# Exterior derivative.
+@test d(0, s, [1,1,1,4]) == [0,0,3]
+@test d(0, s, [4,1,0,0]) == [-3,1,0]
+
 # 2D simplicial sets
 ####################
 
@@ -85,6 +89,7 @@ add_vertices!(s, 3)
 add_sorted_edges!(s, [1,2,3], [2,3,1], edge_orientation=[true,true,false])
 glue_triangle!(s, 1, 2, 3, tri_orientation=true)
 @test ∂(2, s, 1) == [1,1,1]
+@test d(1, s, [45,3,34]) == [82]
 
 # Triangulated square with consistent orientation.
 s = OrientedSimplicialSet2D{Bool}()
@@ -95,5 +100,7 @@ s[:edge_orientation] = true
 s[:tri_orientation] = true
 @test ∂(2, s, 1) == [1,1,-1,0,0]
 @test ∂(2, s, [1,1]) == [1,1,0,1,-1] # 2-chain around perimeter.
+@test d(1, s, [45,3,34,0,0]) == [14,34]  # == [45+3-34, 34]
+@test d(1, s, [45,3,34,17,5]) == [14,46] # == [45+3-34, 34+17-5]
 
 end

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -49,10 +49,14 @@ vvec = ∂₁(s, 1, SparseVector{Int})
 vvec = ∂₁(s, sparsevec([1,-1,1]))
 @test issparse(vvec)
 @test vvec == [-1,0,0,1]
+B = ∂(1, s)
+@test issparse(B)
+@test B*[1,-1,1] == [-1,0,0,1]
 
 # Exterior derivative.
 @test d(0, s, [1,1,1,4]) == [0,0,3]
 @test d(0, s, [4,1,0,0]) == [-3,1,0]
+@test d(0, s) == B'
 
 # 2D simplicial sets
 ####################
@@ -102,5 +106,6 @@ s[:tri_orientation] = true
 @test ∂(2, s, [1,1]) == [1,1,0,1,-1] # 2-chain around perimeter.
 @test d(1, s, [45,3,34,0,0]) == [14,34]  # == [45+3-34, 34]
 @test d(1, s, [45,3,34,17,5]) == [14,46] # == [45+3-34, 34+17-5]
+@test d(1, s) == ∂(2, s)'
 
 end


### PR DESCRIPTION
This PR implements the discrete exterior derivative, aka coboundary operator, in one and two dimensions. 

It also allows matrices, by default sparse, to be constructed for both boundary and coboundary operators. Whether we will need the matrix form is TBD.