### PR TITLE
Wrap parts of simplicial set for more intuitive dispatch

### DIFF
--- a/src/DualSimplicialSets.jl
+++ b/src/DualSimplicialSets.jl
@@ -1,11 +1,10 @@
 """ Dual complexes for simplicial sets in one, two, and three dimensions.
 """
 module DualSimplicialSets
-export
+export DualSimplex, DualV, DualE, DualTri, elementary_duals,
   AbstractDeltaDualComplex1D, DeltaDualComplex1D, OrientedDeltaDualComplex1D,
-  vertex_center, edge_center, elementary_duals,
   AbstractDeltaDualComplex2D, DeltaDualComplex2D, OrientedDeltaDualComplex2D,
-  triangle_center
+  vertex_center, edge_center, triangle_center
 
 using StaticArrays: @SVector, SVector
 
@@ -244,21 +243,43 @@ relative_sign(x::Bool, y::Bool) = (x && y) || (!x && !y)
 # General operators
 ###################
 
+""" Wrapper for dual simplex or simplices of dimension `D`.
+
+See also: [`DualV`](@ref), [`DualE`](@ref), [`DualTri`](@ref).
+"""
+@parts_array DualSimplex{D}
+
+""" Vertex in simplicial set: alias for `Simplex{0}`.
+"""
+const DualV = DualSimplex{0}
+
+""" Edge in simplicial set: alias for `Simplex{1}`.
+"""
+const DualE = DualSimplex{1}
+
+""" Triangle in simplicial set: alias for `Simplex{2}`.
+"""
+const DualTri = DualSimplex{2}
+
 """ List of elementary dual simplices corresponding to primal simplex.
 
 In general, in an ``n``-dimensional complex, the elementary duals of primal
-``k``-simplices are dual ``(n-k)``-simplices. Thus, in 1D dual complexes,
+``k``-simplices are dual ``(n-k)``-simplices. Thus, in 1D dual complexes, the
 elementary duals of...
 
 - primal vertices are dual edges
 - primal edges are (single) dual vertices
 
-In 2D dual complexes, elementary duals of...
+In 2D dual complexes, the elementary duals of...
 
 - primal vertices are dual triangles
 - primal edges are dual edges
 - primal triangles are (single) dual triangles
 """
+@inline elementary_duals(s::AbstractDeltaDualComplex1D, x::Simplex{n}) where n =
+  DualSimplex{1-n}(elementary_duals(Val{n}, s, x.data))
+@inline elementary_duals(s::AbstractDeltaDualComplex2D, x::Simplex{n}) where n =
+  DualSimplex{2-n}(elementary_duals(Val{n}, s, x.data))
 @inline elementary_duals(n::Int, s::AbstractACSet, args...) =
   elementary_duals(Val{n}, s, args...)
 

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -20,7 +20,7 @@ automatically sort their inputs to ensure that the ordering condition is
 satisfied.
 """
 module SimplicialSets
-export ∂, boundary, d, coboundary, exterior_derivative,
+export Simplex, V, E, Tri, ∂, boundary, d, coboundary, exterior_derivative,
   AbstractDeltaSet1D, DeltaSet1D, OrientedDeltaSet1D,
   ∂₁, src, tgt, edge_sign, nv, ne, vertices, edges, has_vertex, has_edge,
   add_vertex!, add_vertices!, add_edge!, add_edges!,
@@ -281,6 +281,24 @@ end
 # General operators
 ###################
 
+""" Wrapper for simplex or simplices of dimension `D`.
+
+See also: [`V`](@ref), [`E`](@ref), [`Tri`](@ref).
+"""
+@parts_array Simplex{D}
+
+""" Vertex in simplicial set: alias for `Simplex{0}`.
+"""
+const V = Simplex{0}
+
+""" Edge in simplicial set: alias for `Simplex{1}`.
+"""
+const E = Simplex{1}
+
+""" Triangle in simplicial set: alias for `Simplex{2}`.
+"""
+const Tri = Simplex{2}
+
 """ Face map and boundary operator on simplicial sets.
 
 Given numbers `n` and `0 <= i <= n` and a simplicial set of dimension at least
@@ -299,6 +317,8 @@ The boundary operator on `n`-faces and `n`-chains is implemented by the call
 Note that the face map returns *simplices*, while the boundary operator returns
 *chains* (vectors in the free vector space spanned by oriented simplices).
 """
+@inline ∂(i::Int, s::AbstractACSet, x::Simplex{n}) where n =
+  Simplex{n-1}(∂(Val{n}, Val{i}, s::AbstractACSet, x.data))
 @inline ∂(n::Int, i::Int, s::AbstractACSet, args...) =
   ∂(Val{n}, Val{i}, s::AbstractACSet, args...)
 

--- a/test/DualSimplicialSets.jl
+++ b/test/DualSimplicialSets.jl
@@ -14,10 +14,14 @@ s = DeltaDualComplex1D(primal_s)
 @test nparts(s, :DualV) == nv(primal_s) + ne(primal_s)
 @test nparts(s, :DualE) == 2 * ne(primal_s)
 
-@test elementary_duals(1,s,4) == [edge_center(s, 4)]
+dual_v = elementary_duals(1,s,4)
+@test dual_v == [edge_center(s, 4)]
+@test elementary_duals(s, E(4)) == DualV(dual_v)
+
 dual_es = elementary_duals(0,s,5)
 @test length(dual_es) == 4
 @test s[dual_es, :D_∂v0] == edge_center(s, 1:4)
+@test elementary_duals(s, V(5)) == DualE(dual_es)
 
 # 1D oriented dual complex
 #-------------------------
@@ -42,10 +46,12 @@ s = DeltaDualComplex2D(primal_s)
 @test nparts(s, :DualE) == 2*ne(primal_s) + 6*ntriangles(primal_s)
 @test nparts(s, :DualTri) == 6*ntriangles(primal_s)
 
-@test elementary_duals(2,s,2) == [triangle_center(s,2)]
+dual_vs = elementary_duals(2,s,2)
+@test dual_vs == [triangle_center(s,2)]
+@test elementary_duals(s, Tri(2)) == DualV(dual_vs)
 @test s[elementary_duals(1,s,2), :D_∂v1] == [edge_center(s,2)]
 @test s[elementary_duals(1,s,3), :D_∂v1] == repeat([edge_center(s,3)], 2)
-@test [length(elementary_duals(0,s,i)) for i in 1:4] == [4,2,4,2]
+@test [length(elementary_duals(s, V(i))) for i in 1:4] == [4,2,4,2]
 
 # 2D oriented dual complex
 #-------------------------

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -24,6 +24,8 @@ add_sorted_edges!(s, [2,4], [3,3])
 @test tgt(s) == [2,3,4]
 @test ∂₁(0, s) == [2,3,4]
 @test ∂₁(1, s) == [1,2,3]
+@test ∂(0, s, E(1)) == V(2)
+@test ∂(1, s, E([1,3])) == V([1,3])
 
 # 1D oriented simplicial sets
 #----------------------------


### PR DESCRIPTION
Add structs `V`, `E`, `Tri` for primal simplices and `DualV`, `DualE`, `DualTri` for dual simplices.

Will be followed by vector types for primal and dual (co)chains. All this should promote readable code and make errors less likely.