### PR TITLE
Custom vector types for chains and cochains

### DIFF
--- a/src/DualSimplicialSets.jl
+++ b/src/DualSimplicialSets.jl
@@ -247,7 +247,7 @@ relative_sign(x::Bool, y::Bool) = (x && y) || (!x && !y)
 
 See also: [`DualV`](@ref), [`DualE`](@ref), [`DualTri`](@ref).
 """
-@parts_array DualSimplex{D}
+@parts_array_struct DualSimplex{D}
 
 """ Vertex in simplicial set: alias for `Simplex{0}`.
 """

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -20,7 +20,9 @@ automatically sort their inputs to ensure that the ordering condition is
 satisfied.
 """
 module SimplicialSets
-export Simplex, V, E, Tri, ∂, boundary, d, coboundary, exterior_derivative,
+export Simplex, V, E, Tri, SimplexChain, VChain, EChain, TriChain,
+  SimplexCochain, VCochain, ECochain, TriCochain,
+  ∂, boundary, d, coboundary, exterior_derivative,
   AbstractDeltaSet1D, DeltaSet1D, OrientedDeltaSet1D,
   ∂₁, src, tgt, edge_sign, nv, ne, vertices, edges, has_vertex, has_edge,
   add_vertex!, add_vertices!, add_edge!, add_edges!,
@@ -281,11 +283,11 @@ end
 # General operators
 ###################
 
-""" Wrapper for simplex or simplices of dimension `D`.
+""" Wrapper for simplex or simplices of dimension `n`.
 
 See also: [`V`](@ref), [`E`](@ref), [`Tri`](@ref).
 """
-@parts_array Simplex{D}
+@parts_array_struct Simplex{n}
 
 """ Vertex in simplicial set: alias for `Simplex{0}`.
 """
@@ -298,6 +300,22 @@ const E = Simplex{1}
 """ Triangle in simplicial set: alias for `Simplex{2}`.
 """
 const Tri = Simplex{2}
+
+""" Wrapper for chain of oriented simplices of dimension `n`.
+"""
+@vector_struct SimplexChain{n}
+
+const VChain = SimplexChain{0}
+const EChain = SimplexChain{1}
+const TriChain = SimplexChain{2}
+
+""" Wrapper for cochain in simplicial set.
+"""
+@vector_struct SimplexCochain{n}
+
+const VCochain = SimplexCochain{0}
+const ECochain = SimplexCochain{1}
+const TriCochain = SimplexCochain{2}
 
 """ Face map and boundary operator on simplicial sets.
 
@@ -325,6 +343,8 @@ Note that the face map returns *simplices*, while the boundary operator returns
 ∂(::Type{Val{1}}, i::Type, s::AbstractACSet, args...) = ∂₁(i, s, args...)
 ∂(::Type{Val{2}}, i::Type, s::AbstractACSet, args...) = ∂₂(i, s, args...)
 
+@inline ∂(s::AbstractACSet, x::SimplexChain{n}) where n =
+  SimplexChain{n-1}(∂(Val{n}, s, x.data))
 @inline ∂(n::Int, s::AbstractACSet, args...) =
   ∂(Val{n}, s::AbstractACSet, args...)
 
@@ -337,6 +357,8 @@ const boundary = ∂
 
 """ The discrete exterior derivative, aka the coboundary operator.
 """
+@inline d(s::AbstractACSet, x::SimplexCochain{n}) where n =
+  SimplexCochain{n+1}(d(Val{n}, s::AbstractACSet, x.data))
 @inline d(n::Int, s::AbstractACSet, args...) =
   d(Val{n}, s::AbstractACSet, args...)
 

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -22,10 +22,10 @@ add_sorted_edge!(s, 2, 1)
 add_sorted_edges!(s, [2,4], [3,3])
 @test src(s) == [1,2,3]
 @test tgt(s) == [2,3,4]
-@test ∂₁(0, s) == [2,3,4]
-@test ∂₁(1, s) == [1,2,3]
-@test ∂(0, s, E(1)) == V(2)
-@test ∂(1, s, E([1,3])) == V([1,3])
+@test ∂(1, 0, s) == [2,3,4]
+@test ∂(1, 1, s) == [1,2,3]
+@test ∂(0, s, E(1))::V == V(2)
+@test ∂(1, s, E([1,3]))::V == V([1,3])
 
 # 1D oriented simplicial sets
 #----------------------------
@@ -43,6 +43,7 @@ vvec = ∂₁(s, 1, Vector{Int})
 vvec = ∂₁(s, [1,-1,1])
 @test !issparse(vvec)
 @test vvec == [-1,0,0,1]
+@test ∂(s, EChain([1,-1,1]))::VChain == VChain(vvec)
 
 # Boundary operator, sparse vectors.
 vvec = ∂₁(s, 1, SparseVector{Int})
@@ -51,13 +52,14 @@ vvec = ∂₁(s, 1, SparseVector{Int})
 vvec = ∂₁(s, sparsevec([1,-1,1]))
 @test issparse(vvec)
 @test vvec == [-1,0,0,1]
+@test ∂(s, EChain(sparsevec([1,-1,1]))) == VChain(vvec)
 B = ∂(1, s)
 @test issparse(B)
 @test B*[1,-1,1] == [-1,0,0,1]
 
 # Exterior derivative.
-@test d(0, s, [1,1,1,4]) == [0,0,3]
-@test d(0, s, [4,1,0,0]) == [-3,1,0]
+@test d(s, VCochain([1,1,1,4]))::ECochain == ECochain([0,0,3])
+@test d(s, VCochain([4,1,0,0])) == ECochain([-3,1,0])
 @test d(0, s) == B'
 
 # 2D simplicial sets
@@ -104,9 +106,11 @@ glue_triangle!(s, 1, 2, 3, tri_orientation=true)
 glue_triangle!(s, 1, 3, 4, tri_orientation=true)
 s[:edge_orientation] = true
 @test ∂(2, s, 1) == [1,1,-1,0,0]
-@test ∂(2, s, [1,1]) == [1,1,0,1,-1] # 2-chain around perimeter.
-@test d(1, s, [45,3,34,0,0]) == [14,34]  # == [45+3-34, 34]
-@test d(1, s, [45,3,34,17,5]) == [14,46] # == [45+3-34, 34+17-5]
+@test ∂(s, TriChain([1,1]))::EChain == EChain([1,1,0,1,-1])
+@test d(s, ECochain([45,3,34,0,0]))::TriCochain ==
+  TriCochain([14, 34]) # == [45+3-34, 34]
+@test d(s, ECochain([45,3,34,17,5])) ==
+  TriCochain([14, 46]) # == [45+3-34, 34+17-5]
 @test d(1, s) == ∂(2, s)'
 
 end


### PR DESCRIPTION
Sequel to #10, adding custom vector types for primal chains and cochains. The boundary and coboundary operations now support these types.