### PR TITLE
Interior product and Lie derivative

### DIFF
--- a/src/ArrayUtils.jl
+++ b/src/ArrayUtils.jl
@@ -62,11 +62,11 @@ nzbuilder(::Type{<:SparseMatrixCSC{Tv}}, m::Integer, n::Integer) where {Tv,Ti} =
 
 """ Apply diagonal operator to dense or sparse vector.
 """
-applydiag(f, x::AbstractVector) = [ f(i)*a for (i,a) in enumerate(x) ]
+applydiag(f, x::AbstractVector) = map(f, eachindex(x), x)
 
 function applydiag(f, x::SparseVector)
   I, V = findnz(x)
-  sparsevec(I, [ f(i)*a for (i,a) in zip(I, V) ], length(x))
+  sparsevec(I, map(f, I, V), length(x))
 end
 
 """ Apply linear map defined in terms of structural nonzero values.

--- a/src/DualSimplicialSets.jl
+++ b/src/DualSimplicialSets.jl
@@ -8,7 +8,8 @@ export DualSimplex, DualV, DualE, DualTri, DualChain, DualForm,
   OrientedDeltaDualComplex2D, EmbeddedDeltaDualComplex2D,
   SimplexCenter, Barycenter, Circumcenter, Incenter, geometric_center,
   subsimplices, primal_vertex, elementary_duals, dual_boundary, dual_derivative,
-  ⋆, hodge_star, δ, codifferential, Δ, laplace_beltrami, ∧, wedge,
+  ⋆, hodge_star, δ, codifferential, Δ, laplace_beltrami, ∧, wedge_product,
+  interior_product, interior_product_flat,
   vertex_center, edge_center, triangle_center, dual_triangle_vertices,
   dual_point, dual_volume, subdivide_duals!
 
@@ -594,13 +595,31 @@ end
 @inline ⋆(n::Int, s::AbstractACSet, args...) = ⋆(Val{n}, s, args...)
 
 ⋆(::Type{Val{n}}, s::AbstractACSet, form::AbstractVector) where n =
-  applydiag(form) do x; hodge_diag(Val{n},s,x) end
+  applydiag(form) do x, a; a * hodge_diag(Val{n},s,x) end
 ⋆(::Type{Val{n}}, s::AbstractACSet) where n =
   Diagonal([ hodge_diag(Val{n},s,x) for x in simplices(n,s) ])
 
 """ Alias for the Hodge star operator [`⋆`](@ref).
 """
 const hodge_star = ⋆
+
+""" Inverse Hodge star operator from dual ``N-n``-forms to primal ``n``-forms.
+
+Confusingly, this is *not* the operator inverse of the Hodge star [`⋆`](@ref)
+because it carries an extra global sign, in analogy to the smooth case
+(Gillette, 2009, Notes on the DEC, Definition 2.27).
+"""
+@inline inv_hodge_star(n::Int, s::AbstractACSet, args...) =
+  inv_hodge_star(Val{n}, s, args...)
+
+function inv_hodge_star(::Type{Val{n}}, s::AbstractACSet,
+                        form::AbstractVector) where n
+  if iseven(n*(ndims(s)-n))
+    applydiag(form) do x, a; a / hodge_diag(Val{n},s,x) end
+  else
+    applydiag(form) do x, a; -a / hodge_diag(Val{n},s,x) end
+  end
+end
 
 """ Codifferential operator from primal ``n`` forms to primal ``n-1``-forms.
 """
@@ -645,9 +664,12 @@ const laplace_beltrami = Δ
 
 """ Wedge product of discrete forms.
 
-Specifically, this is the discrete primal-primal wedge product introduced in
-(Hirani, 2003, Chapter 7) and (Desbrun et al, 2005). It depends on the embedding
-and requires the dual complex.
+The wedge product of a ``k``-form and an ``l``-form is a ``(k+l)``-form.
+
+The DEC and related systems have several flavors of wedge product. This one is
+the discrete primal-primal wedge product introduced in (Hirani, 2003, Chapter 7)
+and (Desbrun et al 2005, Section 8). It depends on the geometric embedding and
+requires the dual complex.
 """
 ∧(s::AbstractACSet, α::SimplexForm{k}, β::SimplexForm{l}) where {k,l} =
   SimplexForm{k+l}(∧(Tuple{k,l}, s, α.data, β.data))
@@ -661,11 +683,14 @@ end
 
 ∧(::Type{Tuple{0,0}}, s::AbstractACSet, f, g, x::Int) = f[x]*g[x]
 ∧(::Type{Tuple{k,0}}, s::AbstractACSet, α, g, x::Int) where k =
-  wedge_zero_form(Val{k}, s, g, α, x)
+  wedge_product_zero(Val{k}, s, g, α, x)
 ∧(::Type{Tuple{0,k}}, s::AbstractACSet, f, β, x::Int) where k =
-  wedge_zero_form(Val{k}, s, f, β, x)
+  wedge_product_zero(Val{k}, s, f, β, x)
 
-function wedge_zero_form(::Type{Val{k}}, s::AbstractACSet, f, α, x::Int) where k
+""" Wedge product of a 0-form and a ``k``-form.
+"""
+function wedge_product_zero(::Type{Val{k}}, s::AbstractACSet,
+                            f, α, x::Int) where k
   subs = subsimplices(k, s, x)
   vs = primal_vertex(k, s, subs)
   coeffs = map(x′ -> dual_volume(k,s,x′), subs) / volume(k,s,x)
@@ -674,7 +699,33 @@ end
 
 """ Alias for the wedge product operator [`∧`](@ref).
 """
-const wedge = ∧
+const wedge_product = ∧
+
+""" Interior product of a vector field (or 1-form) and a ``n``-form.
+
+Specifically, this is the primal-dual interior product defined in (Hirani 2003,
+Section 8.2) and (Desbrun et al 2005, Section 10). Thus it takes a primal vector
+field (or primal 1-form) and a dual ``n``-forms and then returns a dual
+``(n-1)``-form.
+"""
+interior_product(s::AbstractACSet, X♭::EForm, α::DualForm{n}) where n =
+  DualForm{n-1}(interior_product_flat(Val{n}, s, X♭.data, α.data))
+
+""" Interior product of a 1-form and a ``n``-form, yielding an ``(n-1)``-form.
+
+Usually, the interior product is defined for vector fields; this function
+assumes that the flat operator `♭` (not yet implemented) has already been
+applied to yield a 1-form.
+"""
+interior_product_flat(n::Int, s::AbstractACSet, X♭::AbstractVector, args...) =
+  interior_product_flat(Val{n}, s, X♭, args...)
+
+function interior_product_flat(::Type{Val{n}}, s::AbstractACSet,
+                               X♭::AbstractVector, α::AbstractVector) where n
+  # TODO: Global sign `iseven(n*n′) ? +1 : -1`
+  n′ = ndims(s) - n
+  hodge_star(n′+1,s, wedge_product(n′,1,s, inv_hodge_star(n′,s, α), X♭))
+end
 
 # Euclidean geometry
 ####################

--- a/test/DualSimplicialSets.jl
+++ b/test/DualSimplicialSets.jl
@@ -162,7 +162,12 @@ vform, triform = VForm([1.5, 2, 2.5]), TriForm([7.5])
 eform1, eform2 = EForm([1.5, 2, 2.5]), EForm([3, 7, 10])
 @test ∧(s, eform1, eform1)::TriForm ≈ TriForm([0])
 @test ∧(s, eform1, eform2) ≈ -∧(s, eform2, eform1)
-@test interior_product(s, eform1, DualForm{1}([3, 7, 10])) isa DualForm{0}
+
+X♭, α = EForm([1.5, 2, 2.5]), DualForm{1}([3, 7, 10])
+@test interior_product(s, X♭, α) isa DualForm{0}
+@test length(interior_product_flat(1,s, X♭.data, α.data)) == 1
+@test lie_derivative(s, X♭, α) isa DualForm{1}
+@test length(lie_derivative_flat(1,s, X♭.data, α.data)) == 3
 
 subdivide_duals!(s, Circumcenter())
 @test dual_point(s, triangle_center(s, 1)) ≈ Point2D(1/2, 1/2)

--- a/test/DualSimplicialSets.jl
+++ b/test/DualSimplicialSets.jl
@@ -162,6 +162,7 @@ vform, triform = VForm([1.5, 2, 2.5]), TriForm([7.5])
 eform1, eform2 = EForm([1.5, 2, 2.5]), EForm([3, 7, 10])
 @test ∧(s, eform1, eform1)::TriForm ≈ TriForm([0])
 @test ∧(s, eform1, eform2) ≈ -∧(s, eform2, eform1)
+@test interior_product(s, eform1, DualForm{1}([3, 7, 10])) isa DualForm{0}
 
 subdivide_duals!(s, Circumcenter())
 @test dual_point(s, triangle_center(s, 1)) ≈ Point2D(1/2, 1/2)


### PR DESCRIPTION
Sequel to #22. We have not implemented the flat operator, so the interior product and Lie derivative operators take a 1-form rather than a vector field (i.e., we assume that the flat has already been applied).