### PR TITLE
Mesh support for STL files

### DIFF
--- a/src/CombinatorialSpaces.jl
+++ b/src/CombinatorialSpaces.jl
@@ -10,7 +10,7 @@ include("DualSimplicialSets.jl")
 include("MeshInterop.jl")
 
 function __init__()
-  @require AbstractPlotting="537997a7-5e4e-5d89-9595-2241ea00577e" include("MeshGraphics.jl")
+  @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("MeshGraphics.jl")
 end
 
 @reexport using .SimplicialSets

--- a/src/MeshGraphics.jl
+++ b/src/MeshGraphics.jl
@@ -14,28 +14,28 @@ module MeshGraphics
 using Catlab.CategoricalAlgebra
 using ..SimplicialSets
 using ..MeshInterop
-#import ...AbstractPlotting: wireframe, wireframe!, mesh, mesh!, scatter, scatter!
+#import ...Makie: wireframe, wireframe!, mesh, mesh!, scatter, scatter!
 #
 #export wireframe, wireframe!, mesh, mesh!, scatter, scatter!
 
-import ...AbstractPlotting
-import ...AbstractPlotting: convert_arguments
+import ...Makie
+import ...Makie: convert_arguments
 
 """ This extends the "Mesh" plotting recipe for embedded deltasets by converting
-an embedded deltaset into arguments that can be passed into AbstractPlotting.mesh
+an embedded deltaset into arguments that can be passed into Makie.mesh
 """
 
-function convert_arguments(P::Union{Type{<:AbstractPlotting.Wireframe},
-                                    Type{<:AbstractPlotting.Mesh},
-                                    Type{<:AbstractPlotting.Scatter}},
+function convert_arguments(P::Union{Type{<:Makie.Wireframe},
+                                    Type{<:Makie.Mesh},
+                                    Type{<:Makie.Scatter}},
                            dset::AbstractACSet)
   convert_arguments(P, Mesh(dset))
 end
 
 """ This extends the "LineSegments" plotting recipe for embedded deltasets by converting
-an embedded deltaset into arguments that can be passed into AbstractPlotting.linesegments
+an embedded deltaset into arguments that can be passed into Makie.linesegments
 """
-function convert_arguments(P::Type{<:AbstractPlotting.LineSegments}, dset::EmbeddedDeltaSet2D)
+function convert_arguments(P::Type{<:Makie.LineSegments}, dset::EmbeddedDeltaSet2D)
   edge_positions = zeros(ne(dset)*2,3)
   for e in edges(dset)
     edge_positions[2*e-1,:] = point(dset, dset[e,:src])

--- a/src/MeshInterop.jl
+++ b/src/MeshInterop.jl
@@ -48,13 +48,20 @@ end
 This operator should work for any triangular mesh object. Note that it will
 not preserve any normal, texture, or other attributes from the Mesh object.
 """
-function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh)
+function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh; force_unique=false)
   coords = coordinates(m)
+  ind_map = collect(1:length(coords))
+  if(force_unique) 
+    indices = unique(i->coords[i], 1:length(coords))
+    val2ind = Dict(coords[indices[i]]=>i for i in 1:length(indices))
+    ind_map = map(c->val2ind[c], coords)
+    coords = coords[indices]
+  end
   tris = faces(m)
   s = EmbeddedDeltaSet2D{Bool, eltype(coords)}()
   add_vertices!(s, length(coords), point=coords)
   for tri in tris
-    tri = convert.(Int64, tri)
+    tri = ind_map[convert.(Int64, tri)]
     glue_sorted_triangle!(s, tri...)
   end
   # Properly orient the delta set
@@ -69,6 +76,10 @@ that it will not preserve any normal, texture, or other data beyond points and
 triangles from the mesh file.
 """
 function EmbeddedDeltaSet2D(fn::String)
-	EmbeddedDeltaSet2D(FileIO.load(fn))
+  if(fn[(end-2):end] == "stl")
+    EmbeddedDeltaSet2D(FileIO.load(fn); force_unique=true)
+  else
+    EmbeddedDeltaSet2D(FileIO.load(fn))
+  end
 end
 end

--- a/src/MeshInterop.jl
+++ b/src/MeshInterop.jl
@@ -49,7 +49,7 @@ This operator should work for any triangular mesh object. Note that it will
 not preserve any normal, texture, or other attributes from the Mesh object.
 """
 function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh; force_unique=false)
-  coords = coordinates(m)
+  coords = metafree.(coordinates(m))
   ind_map = collect(1:length(coords))
   if(force_unique) 
     indices = unique(i->coords[i], 1:length(coords))

--- a/src/MeshInterop.jl
+++ b/src/MeshInterop.jl
@@ -47,10 +47,13 @@ end
 
 This operator should work for any triangular mesh object. Note that it will
 not preserve any normal, texture, or other attributes from the Mesh object.
+
+The force_unique flag merges all points which are at the same location. This is
+necessary to process `.stl` files which references points by location.
 """
 function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh; force_unique=false)
   coords = metafree.(coordinates(m))
-  ind_map = collect(1:length(coords))
+  ind_map = 1:length(coords)
   if(force_unique) 
     indices = unique(i->coords[i], 1:length(coords))
     val2ind = Dict(coords[indices[i]]=>i for i in 1:length(indices))
@@ -76,7 +79,9 @@ that it will not preserve any normal, texture, or other data beyond points and
 triangles from the mesh file.
 """
 function EmbeddedDeltaSet2D(fn::String)
-  if(fn[(end-2):end] == "stl")
+  if(splitext(fn)[2] == ".stl")
+    # The .stl format references points by location so we apply the
+    # force_unique flag
     EmbeddedDeltaSet2D(FileIO.load(fn); force_unique=true)
   else
     EmbeddedDeltaSet2D(FileIO.load(fn))

--- a/test/MeshGraphics.jl
+++ b/test/MeshGraphics.jl
@@ -8,7 +8,7 @@ using StaticArrays: SVector
 
 const Point3D = SVector{3,Float64}
 
-CairoMakie.AbstractPlotting.inline!(true)
+CairoMakie.Makie.inline!(true)
 
 s = EmbeddedDeltaSet2D(joinpath(@__DIR__, "assets", "square.obj"))
 sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s)

--- a/test/MeshInterop.jl
+++ b/test/MeshInterop.jl
@@ -12,6 +12,10 @@ const Point3D = SVector{3,Float64}
 # Import Tooling
 ################
 
+s_stl = EmbeddedDeltaSet2D(joinpath(@__DIR__, "assets", "square.stl"))
+@test s_stl isa EmbeddedDeltaSet2D
+@test triangle_vertices(s_stl, 1) == [1,2,3]
+
 s = EmbeddedDeltaSet2D(joinpath(@__DIR__, "assets", "square.obj"))
 @test s isa EmbeddedDeltaSet2D
 @test triangle_vertices(s, 1) == [1,2,3]

--- a/test/assets/square.stl
+++ b/test/assets/square.stl
@@ -1,0 +1,16 @@
+solid square
+facet normal 0.0e+00 0.0e+00 1.0e+00
+  outer loop
+    vertex 0.0e+00 0.0e+00 0.0e+00 
+    vertex 0.0e+00 1.0e+00 0.0e+00
+    vertex 1.0e+00 1.0e+00 0.0e+00
+  endloop
+endfacet
+facet normal 0.0e+00 0.0e+00 1.0e+00
+  outer loop
+    vertex 0.0e+00 0.0e+00 0.0e+00 
+    vertex 1.0e+00 0.0e+00 0.0e+00
+    vertex 1.0e+00 1.0e+00 0.0e+00
+  endloop
+endfacet
+endsolid square


### PR DESCRIPTION
With the current mesh tooling, STL formatted mesh files are imported with each triangle disconnected from its neighbors. 
This PR merges these meshes pointwise (points at the same place are merged into a single point) in the conversion to delta sets. 