### PR TITLE
Rename module for discrete exterior caclulus

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,3 @@ julia = "1.5"
 
 [extras]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "CairoMakie"]

--- a/src/CombinatorialSpaces.jl
+++ b/src/CombinatorialSpaces.jl
@@ -6,7 +6,7 @@ using Requires
 include("ArrayUtils.jl")
 include("CombinatorialMaps.jl")
 include("SimplicialSets.jl")
-include("DualSimplicialSets.jl")
+include("DiscreteExteriorCalculus.jl")
 include("MeshInterop.jl")
 
 function __init__()
@@ -14,7 +14,7 @@ function __init__()
 end
 
 @reexport using .SimplicialSets
-@reexport using .DualSimplicialSets
+@reexport using .DiscreteExteriorCalculus
 @reexport using .MeshInterop
 
 end

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -1,7 +1,14 @@
-""" Dual complexes for simplicial sets in one, two, and three dimensions.
+""" The discrete exterior calculus (DEC) for simplicial sets.
+
+This module provides the dual complex associated with a delta set (the primal
+complex), which is a discrete incarnation of Hodge duality, as well as the many
+operators of the DEC that depend on it, such as the Hodge star, codifferential,
+wedge product, interior product, and Lie derivative. The main reference for this
+module is Hirani's 2003 PhD thesis.
 """
-module DualSimplicialSets
-export DualSimplex, DualV, DualE, DualTri, DualChain, DualForm, DualVectorField,
+module DiscreteExteriorCalculus
+export DualSimplex, DualV, DualE, DualTri, DualChain, DualForm,
+  PrimalVectorField, DualVectorField,
   AbstractDeltaDualComplex1D, DeltaDualComplex1D,
   OrientedDeltaDualComplex1D, EmbeddedDeltaDualComplex1D,
   AbstractDeltaDualComplex2D, DeltaDualComplex2D,
@@ -548,6 +555,10 @@ this correspondence, a basis for primal ``n``-chains defines the basis for dual
 """
 @vector_struct DualForm{n}
 
+""" Wrapper for vector field on primal vertices.
+"""
+@vector_struct PrimalVectorField
+
 """ Wrapper for vector field on dual vertices.
 """
 @vector_struct DualVectorField
@@ -749,7 +760,7 @@ implemented.
 
 See also: the flat operator [`♭`](@ref).
 """
-♯(s::AbstractACSet, α::EForm) = VectorField(♯(s, α.data, PPSharp()))
+♯(s::AbstractACSet, α::EForm) = PrimalVectorField(♯(s, α.data, PPSharp()))
 
 """ Alias for the sharp operator [`♯`](@ref).
 """

--- a/src/MeshGraphics.jl
+++ b/src/MeshGraphics.jl
@@ -1,14 +1,10 @@
-""" Visualization for Delta Sets and their duals.
+""" Visualization of delta sets and dual complexes.
 
-This module provides wrapper functions for plotting embedded delta sets
-using the Makie functionality. This includes the wireframe, mesh, and scatter
-plotting functions.
-
-It is important to note that the end-user will need to import one of the Makie
-backends (CairoMakie, GLMakie, or WGLMakie) in order for plotting to work
-correctly.
+This module providers wrapper functions to plotting embedded delta sets using
+Makie.jl, including wireframe, mesh, and scatter plots. Note that one of the
+Makie backends (CairoMakie, GLMakie, or WGLMakie) must be imported in order for
+plotting to work.
 """
-
 module MeshGraphics
 
 using Catlab.CategoricalAlgebra
@@ -18,6 +14,7 @@ using ..MeshInterop
 #
 #export wireframe, wireframe!, mesh, mesh!, scatter, scatter!
 
+using GeometryBasics: Mesh
 import ...Makie
 import ...Makie: convert_arguments
 

--- a/src/MeshInterop.jl
+++ b/src/MeshInterop.jl
@@ -12,7 +12,7 @@ using FileIO, MeshIO, GeometryBasics
 import GeometryBasics: Mesh
 
 using Catlab.CategoricalAlgebra: copy_parts!
-using ..SimplicialSets, ..DualSimplicialSets
+using ..SimplicialSets, ..DiscreteExteriorCalculus
 import ..SimplicialSets: EmbeddedDeltaSet2D
 
 # Helper Functions (should these be exposed?)

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -6,10 +6,15 @@ sets](https://ncatlab.org/nlab/show/semi-simplicial+set). These include the face
 maps but not the degeneracy maps of a simplicial set. In the future we may add
 support for simplicial sets. The analogy to keep in mind is that graphs are to
 semi-simpicial sets as reflexive graphs are to simplicial sets.
+
+Also provided are the fundamental operators on simplicial sets used in virtually
+all geometric applications, namely the boundary and coboundary (discrete
+exterior derivative). For additional operators, see the
+`DiscreteExteriorCalculus` module.
 """
 module SimplicialSets
 export Simplex, V, E, Tri, SimplexChain, VChain, EChain, TriChain,
-  SimplexForm, VForm, EForm, TriForm, VectorField,
+  SimplexForm, VForm, EForm, TriForm,
   AbstractDeltaSet1D, DeltaSet1D, OrientedDeltaSet1D, EmbeddedDeltaSet1D,
   AbstractDeltaSet2D, DeltaSet2D, OrientedDeltaSet2D, EmbeddedDeltaSet2D,
   ∂, boundary, coface, d, coboundary, exterior_derivative,
@@ -310,10 +315,6 @@ const TriChain = SimplexChain{2}
 const VForm = SimplexForm{0}
 const EForm = SimplexForm{1}
 const TriForm = SimplexForm{2}
-
-""" Wrapper for vector field on vertices of simplicial set.
-"""
-@vector_struct VectorField
 
 """ Simplices of given dimension in a simplicial set.
 """

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -1,4 +1,4 @@
-module TestDualSimplicialSets
+module TestDiscreteExteriorCalculus
 using Test
 
 using LinearAlgebra: Diagonal
@@ -186,7 +186,7 @@ x̂, ŷ, zero = @SVector([1,0]), @SVector([0,1]), @SVector([0,0])
 @test ♭(s, DualVectorField([ŷ, -ŷ])) ≈ EForm([0,-2,0,0,2])
 @test ♭(s, DualVectorField([(x̂-ŷ)/√2, (x̂-ŷ)/√2]))[3] ≈ 2*√2
 @test ♭(s, DualVectorField([(x̂-ŷ)/√2, zero]))[3] ≈ √2
-X = ♯(s, EForm([2,0,0,2,0]))::VectorField
+X = ♯(s, EForm([2,0,0,2,0]))::PrimalVectorField
 @test X[2][1] > 0 && X[4][1] < 0
 X = ♯(s, EForm([0,-2,0,0,2]))
 @test X[2][2] > 0 && X[4][2] < 0

--- a/test/MeshInterop.jl
+++ b/test/MeshInterop.jl
@@ -2,15 +2,14 @@ module TestMeshInterop
 using Test
 
 using CombinatorialSpaces
-using CombinatorialSpaces.MeshInterop
 
 using GeometryBasics
 using StaticArrays: SVector
 
 const Point3D = SVector{3,Float64}
 
-# Import Tooling
-################
+# Import meshes
+###############
 
 s_stl = EmbeddedDeltaSet2D(joinpath(@__DIR__, "assets", "square.stl"))
 @test s_stl isa EmbeddedDeltaSet2D
@@ -22,6 +21,9 @@ s = EmbeddedDeltaSet2D(joinpath(@__DIR__, "assets", "square.obj"))
 
 sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s)
 subdivide_duals!(sd, Barycenter())
+
+# Export meshes
+###############
 
 # Test consistency with conversion to/from mesh.
 msh = Mesh(s)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+CombinatorialSpaces = "b1c52339-7909-45ad-8b6a-6e388f7c67f2"
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,10 @@ end
 
 @testset "SimplicialSets" begin
   include("SimplicialSets.jl")
-  include("DualSimplicialSets.jl")
+end
+
+@testset "ExteriorCalculus" begin
+  include("DiscreteExteriorCalculus.jl")
 end
 
 @testset "Meshes" begin


### PR DESCRIPTION
The name change reflects the more standard terminology (`DiscreteExteriorCalculus` instead of `DualSimplicialSets`) and will also enable a sane organizational scheme when we add a GAT for exterior calculus or a new module for finite element exterior calculus.