### PR TITLE
Updated Hodge Star for 1-Forms

### DIFF
--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -1035,19 +1035,19 @@ vector field.
   lie_derivative_flat(Val{n}, s, args...; kw...)
 
 function lie_derivative_flat(::Type{Val{0}}, s::AbstractACSet,
-                             X♭::AbstractVector, α::AbstractVector)
-  interior_product_flat(1, s, X♭, dual_derivative(0, s, α))
+                             X♭::AbstractVector, α::AbstractVector; kw...)
+  interior_product_flat(1, s, X♭, dual_derivative(0, s, α); kw...)
 end
 
 function lie_derivative_flat(::Type{Val{1}}, s::AbstractACSet,
-                             X♭::AbstractVector, α::AbstractVector)
-  interior_product_flat(2, s, X♭, dual_derivative(1, s, α)) +
-    dual_derivative(0, s, interior_product_flat(1, s, X♭, α))
+                             X♭::AbstractVector, α::AbstractVector; kw...)
+  interior_product_flat(2, s, X♭, dual_derivative(1, s, α); kw...) +
+    dual_derivative(0, s, interior_product_flat(1, s, X♭, α; kw...))
 end
 
 function lie_derivative_flat(::Type{Val{2}}, s::AbstractACSet,
-                             X♭::AbstractVector, α::AbstractVector)
-  dual_derivative(1, s, interior_product_flat(2, s, X♭, α))
+                             X♭::AbstractVector, α::AbstractVector; kw...)
+  dual_derivative(1, s, interior_product_flat(2, s, X♭, α; kw...))
 end
 
 # Euclidean geometry

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -887,6 +887,15 @@ operator [`∇²`](@ref): ``Δ f = -∇² f``.
   δ(n+1,s; matrix=matrix, kw...) * d(Val{n},s,matrix) +
 		d(Val{n-1},s,matrix) * δ(n,s; matrix=matrix, kw...)
 
+Δ(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, form::AbstractVector; kw...) =
+  d(Val{0}, s, δ(1, s, form; kw...))
+Δ(::Type{Val{1}}, s::AbstractDeltaDualComplex1D; matrix::Type=SparseMatrixCSC{Float64}, kw...) =
+  d(Val{0},s,matrix) * δ(1,s; matrix=matrix, kw...)
+
+Δ(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, form::AbstractVector; kw...) =
+  d(Val{1}, s, δ(2, s, form; kw...))
+Δ(::Type{Val{2}}, s::AbstractDeltaDualComplex2D; matrix::Type=SparseMatrixCSC{Float64}, kw...) =
+  d(Val{1},s,matrix) * δ(2,s; matrix=matrix, kw...)
 """ Alias for the Laplace-de Rham operator [`Δ`](@ref).
 """
 const laplace_de_rham = Δ

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -694,8 +694,8 @@ function ⋆(::Type{Val{1}}, s::AbstractDeltaDualComplex2D)
     end
 
     diag_dot = map(1:3) do i
-             dot(ev[i], dv[i]) / norm(ev[i])^2
-           end
+      dot(ev[i], dv[i]) / dot(ev[i], ev[i])
+    end
 
     for i in 1:3
       diag_cross = sign(Val{2}, s, t) * crossdot(ev[i], dv[i]) /

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -689,15 +689,18 @@ function ⋆(::Type{Val{1}}, s::AbstractACSet)
     dv = fill(dual_point(s, triangle_center(s, t)),3) .- dual_point(s, edge_center(s, e))
     dv[2] *= -1
 
+    diag_dot = map(1:3) do i
+             dot(ev[i], dv[i]) / norm(ev[i])^2
+           end
+
     for i in 1:3
       diag_cross = sign(Val{2}, s, t) * crossdot(ev[i], dv[i]) / norm(ev[i])^2
       add_val!(vals, (e[i], e[i]), diag_cross)
     end
 
     for p ∈ [[1,2,3], [1,3,2], [2,1,3], [2,3,1], [3,1,2], [3,2,1]]
-      diag_dot = dot(ev[i], dv[i]) / norm(ev[i])^2
-      val = sign(Val{2}, s, t) *
-            diag_dot * dot(ev[p[1]], ev[p[3]]) / crossdot(ev[p[2]], ev[p[3]])
+      val = sign(Val{2}, s, t) * diag_dot[p[1]] * dot(ev[p[1]], ev[p[3]]) /
+              crossdot(ev[p[2]], ev[p[3]])
       add_val!(vals, (e[p[1]], e[p[2]]), val)
     end
   end

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -6,6 +6,7 @@ using SparseArrays, StaticArrays
 
 using Catlab.CategoricalAlgebra.CSets
 using CombinatorialSpaces
+using CombinatorialSpaces.DiscreteExteriorCalculus: inv_hodge_star
 
 const Point2D = SVector{2,Float64}
 const Point3D = SVector{3,Float64}
@@ -85,6 +86,17 @@ subdivide_duals!(s, Barycenter())
 f = VForm([0,1,2,1,0])
 @test Δ(s,f) ≈ -∇²(s,f)
 
+@test isapprox(Δ(0, s), [-2  2  0  0  0;
+                          1 -2  1  0  0;
+                          0  1 -2  1  0;
+                          0  0  1 -2  1;
+                          0  0  0  2 -2], atol=1e-3)
+
+@test isapprox(Δ(1, s), [-3.0  1.0  0.0  0.0;
+                          1.0 -2.0  1.0  0.0;
+                          0.0  1.0 -2.0  1.0;
+                          0.0  0.0  1.0 -3.0], atol=1e-3)
+
 # 2D dual complex
 #################
 
@@ -155,6 +167,9 @@ subdivide_duals!(s, Barycenter())
 @test ⋆(1,s) ≈ [1/3 0.0 1/6;
                 0.0 1/6 0.0;
                 1/6 0.0 1/3]
+
+@test inv_hodge_star(2, s)[1,1] ≈ 0.5
+@test inv_hodge_star(2, s, [2.0])[1,1] ≈ 1.0
 @test ⋆(s, VForm([1,2,3]))::DualForm{2} ≈ DualForm{2}([1/6, 1/3, 1/2])
 @test isapprox(δ(1,s; hodge=DiagonalHodge()), [ 2.236  0  2.236;
                                               -2.236  1  0;
@@ -164,6 +179,7 @@ subdivide_duals!(s, Barycenter())
                          -1  -1 -2.0], atol=1e-3)
 @test δ(s, EForm([0.5,1.5,0.5])) isa VForm
 @test Δ(s, EForm([1.,2.,1.])) isa EForm
+@test Δ(s, TriForm([1.])) isa TriForm
 
 @test isapprox(Δ(0, s), [-6  3  3;
                           3 -3  0;

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -6,7 +6,6 @@ using SparseArrays, StaticArrays
 
 using Catlab.CategoricalAlgebra.CSets
 using CombinatorialSpaces
-using CombinatorialSpaces.DiscreteExteriorCalculus: inv_hodge_star
 
 const Point2D = SVector{2,Float64}
 const Point3D = SVector{3,Float64}
@@ -166,6 +165,9 @@ subdivide_duals!(s, Barycenter())
 @test ⋆(0,s) ≈ Diagonal([1/6, 1/6, 1/6])
 
 @test ⋆(1,s; hodge=DiagonalHodge()) ≈ Diagonal([√5/6, 1/6, √5/6])
+
+# This test is consistent with Ayoub et al 2020 page 13 (up to permutation of
+# vertices)
 @test ⋆(1,s) ≈ [1/3 0.0 1/6;
                 0.0 1/6 0.0;
                 1/6 0.0 1/3]

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -150,11 +150,13 @@ subdivide_duals!(s, Barycenter())
 @test volume(s, elementary_duals(s, V(1))) ≈ [1/12, 1/12]
 @test [sum(volume(s, elementary_duals(s, V(i)))) for i in 1:3] ≈ [1/6, 1/6, 1/6]
 @test ⋆(0,s) ≈ Diagonal([1/6, 1/6, 1/6])
+
+@test ⋆(1,s; hodge=DiagonalHodge()) ≈ Diagonal([√5/6, 1/6, √5/6])
 @test ⋆(1,s) ≈ [1/3 0.0 1/6;
                 0.0 1/6 0.0;
                 1/6 0.0 1/3]
 @test ⋆(s, VForm([1,2,3]))::DualForm{2} ≈ DualForm{2}([1/6, 1/3, 1/2])
-@test isapprox(δ(Val{1},s, DiagonalHodge()), [ 2.236  0  2.236;
+@test isapprox(δ(1,s; hodge=DiagonalHodge()), [ 2.236  0  2.236;
                                               -2.236  1  0;
                                                0     -1 -2.236], atol=1e-3)
 @test isapprox(δ(1,s), [ 3.0  0  3.0;
@@ -178,7 +180,7 @@ subdivide_duals!(s, Incenter())
                         0.000 0.207 0.000;
                         0.207 0.000 0.293], atol=1e-3)
 
-@test isapprox(δ(Val{1},s, DiagonalHodge()), [ 2.449  0      2.449;
+@test isapprox(δ(1,s; hodge=DiagonalHodge()), [ 2.449  0      2.449;
                                               -2.029  1.172  0;
                                                0     -1.172 -2.029], atol=1e-3)
 

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -154,9 +154,12 @@ subdivide_duals!(s, Barycenter())
                 0.0 1/6 0.0;
                 1/6 0.0 1/3]
 @test ⋆(s, VForm([1,2,3]))::DualForm{2} ≈ DualForm{2}([1/6, 1/3, 1/2])
-@test isapprox(δ(1,s), [ 2.236  0  2.236;
-                        -2.236  1  0;
-                         0     -1 -2.236], atol=1e-3)
+@test isapprox(δ(Val{1},s, DiagonalHodge()), [ 2.236  0  2.236;
+                                              -2.236  1  0;
+                                               0     -1 -2.236], atol=1e-3)
+@test isapprox(δ(1,s), [ 3.0  0  3.0;
+                        -2.0  1 -1.0;
+                         -1  -1 -2.0], atol=1e-3)
 @test δ(s, EForm([0.5,1.5,0.5])) isa VForm
 @test Δ(s, EForm([1.,2.,1.])) isa EForm
 
@@ -174,9 +177,14 @@ subdivide_duals!(s, Incenter())
 @test isapprox(⋆(1,s), [0.293 0.000 0.207;
                         0.000 0.207 0.000;
                         0.207 0.000 0.293], atol=1e-3)
-@test isapprox(δ(1,s), [ 2.449  0      2.449;
-                        -2.029  1.172  0;
-                         0     -1.172 -2.029], atol=1e-3)
+
+@test isapprox(δ(Val{1},s, DiagonalHodge()), [ 2.449  0      2.449;
+                                              -2.029  1.172  0;
+                                               0     -1.172 -2.029], atol=1e-3)
+
+@test isapprox(δ(1,s), [ 3.414  0.000  3.414;
+                        -1.657  1.172 -1.172;
+                        -1.172 -1.172 -1.657], atol=1e-3)
 
 # Triangulated square with consistent orientation.
 primal_s = EmbeddedDeltaSet2D{Bool,Point2D}()

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -256,21 +256,21 @@ eform1, eform2 = EForm([1.5, 2, 2.5, 3, 3.5]), EForm([3, 7, 10, 11, 15])
 
 # Lie derivative of flattened vector-field on dual 0-form
 X♭, α = EForm([1.5, 2, 2.5, 3, 3.5]), DualForm{0}([3, 7])
-@test ℒ(s, X♭, α) isa DualForm{0}
+@test ℒ(s, X♭, α; hodge=GeometricHodge()) isa DualForm{0}
 @test length(lie_derivative_flat(0,s, X♭.data, α.data)) == 2
 
 # Lie derivative of flattened vector-field on dual 1-form
 X♭, α = EForm([1.5, 2, 2.5, 3, 3.5]), DualForm{1}([3, 7, 10, 11, 15])
 @test interior_product(s, X♭, α) isa DualForm{0}
 @test length(interior_product_flat(1,s, X♭.data, α.data)) == 2
-@test ℒ(s, X♭, α) isa DualForm{1}
+@test ℒ(s, X♭, α; hodge=GeometricHodge()) isa DualForm{1}
 @test length(lie_derivative_flat(1,s, X♭.data, α.data)) == 5
 
 # Lie derivative of flattened vector-field on dual 2-form
 X♭, α = EForm([1.5, 2, 2.5, 3, 3.5]), DualForm{2}([3, 7, 10, 11])
 @test interior_product(s, X♭, α) isa DualForm{1}
 @test length(interior_product_flat(2,s, X♭.data, α.data)) == 5
-@test ℒ(s, X♭, α) isa DualForm{2}
+@test ℒ(s, X♭, α; hodge=GeometricHodge()) isa DualForm{2}
 @test length(lie_derivative_flat(2,s, X♭.data, α.data)) == 4
 
 end

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -165,6 +165,16 @@ subdivide_duals!(s, Barycenter())
 @test δ(s, EForm([0.5,1.5,0.5])) isa VForm
 @test Δ(s, EForm([1.,2.,1.])) isa EForm
 
+@test isapprox(Δ(0, s), [-6  3  3;
+                          3 -3  0;
+                          3  0 -3], atol=1e-3)
+
+@test isapprox(Δ(1, s), [7   13 -16;
+                         13  10 -13;
+                        -16 -13  7], atol=1e-3)
+
+@test isapprox(Δ(2, s), reshape([36.0], (1,1)), atol=1e-3)
+
 subdivide_duals!(s, Circumcenter())
 @test dual_point(s, triangle_center(s, 1)) ≈ Point2D(1/2, 1/2)
 @test ⋆(0,s) ≈ Diagonal([1/4, 1/8, 1/8])

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -85,6 +85,8 @@ subdivide_duals!(s, Barycenter())
                   0  0  0 -2  2]
 f = VForm([0,1,2,1,0])
 @test Δ(s,f) ≈ -∇²(s,f)
+@test Δ(s, EForm([0,1,1,0])) isa EForm
+@test Δ(s, EForm([0,1,1,0]), hodge=DiagonalHodge()) isa EForm
 
 @test isapprox(Δ(0, s), [-2  2  0  0  0;
                           1 -2  1  0  0;
@@ -170,6 +172,8 @@ subdivide_duals!(s, Barycenter())
 
 @test inv_hodge_star(2, s)[1,1] ≈ 0.5
 @test inv_hodge_star(2, s, [2.0])[1,1] ≈ 1.0
+@test inv_hodge_star(1, s, hodge=DiagonalHodge()) ≈ Diagonal([-6/√5, -6, -6/√5])
+@test inv_hodge_star(1, s, [0.5, 2.0, 0.5], hodge=DiagonalHodge()) ≈ [-3/√5, -12.0, -3/√5]
 @test ⋆(s, VForm([1,2,3]))::DualForm{2} ≈ DualForm{2}([1/6, 1/3, 1/2])
 @test isapprox(δ(1,s; hodge=DiagonalHodge()), [ 2.236  0  2.236;
                                               -2.236  1  0;
@@ -179,8 +183,9 @@ subdivide_duals!(s, Barycenter())
                          -1  -1 -2.0], atol=1e-3)
 @test δ(s, EForm([0.5,1.5,0.5])) isa VForm
 @test Δ(s, EForm([1.,2.,1.])) isa EForm
+@test Δ(s, EForm([1.,2.,1.]); hodge=DiagonalHodge()) isa EForm
 @test Δ(s, TriForm([1.])) isa TriForm
-
+@test Δ(s, TriForm([1.]); hodge=DiagonalHodge()) isa TriForm
 @test isapprox(Δ(0, s), [-6  3  3;
                           3 -3  0;
                           3  0 -3], atol=1e-3)
@@ -189,7 +194,13 @@ subdivide_duals!(s, Barycenter())
                          13  10 -13;
                         -16 -13  7], atol=1e-3)
 
+@test isapprox(Δ(1, s; hodge=DiagonalHodge()),
+                        [0.894  6.367 -7.603;
+                        14.236 10.0  -14.236;
+                        -7.603 -6.367  0.894], atol=1e-2)
+
 @test isapprox(Δ(2, s), reshape([36.0], (1,1)), atol=1e-3)
+@test isapprox(Δ(2, s; hodge=DiagonalHodge()), reshape([22.733], (1,1)), atol=1e-3)
 
 subdivide_duals!(s, Circumcenter())
 @test dual_point(s, triangle_center(s, 1)) ≈ Point2D(1/2, 1/2)

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -162,9 +162,13 @@ subdivide_duals!(s, Barycenter())
 @test volume(s, Tri(1)) ≈ 1/2
 @test volume(s, elementary_duals(s, V(1))) ≈ [1/12, 1/12]
 @test [sum(volume(s, elementary_duals(s, V(i)))) for i in 1:3] ≈ [1/6, 1/6, 1/6]
-@test ⋆(0,s) ≈ Diagonal([1/6, 1/6, 1/6])
 
+# These values are consistent with the Gillette paper, as described above
+@test ⋆(0,s) ≈ Diagonal([1/6, 1/6, 1/6])
 @test ⋆(1,s; hodge=DiagonalHodge()) ≈ Diagonal([√5/6, 1/6, √5/6])
+@test isapprox(δ(1,s; hodge=DiagonalHodge()), [ 2.236  0  2.236;
+                                              -2.236  1  0;
+                                               0     -1 -2.236], atol=1e-3)
 
 # This test is consistent with Ayoub et al 2020 page 13 (up to permutation of
 # vertices)
@@ -172,14 +176,17 @@ subdivide_duals!(s, Barycenter())
                 0.0 1/6 0.0;
                 1/6 0.0 1/3]
 
+# NOTICE:
+# Tests beneath this comment are not backed up by any external source, and are
+# included to determine consistency as the operators are modified.
+#
+# If a test beneath this comment fails due to a new implementation, it is
+# possible that the values for the test itself need to be modified.
 @test inv_hodge_star(2, s)[1,1] ≈ 0.5
 @test inv_hodge_star(2, s, [2.0])[1,1] ≈ 1.0
 @test inv_hodge_star(1, s, hodge=DiagonalHodge()) ≈ Diagonal([-6/√5, -6, -6/√5])
 @test inv_hodge_star(1, s, [0.5, 2.0, 0.5], hodge=DiagonalHodge()) ≈ [-3/√5, -12.0, -3/√5]
 @test ⋆(s, VForm([1,2,3]))::DualForm{2} ≈ DualForm{2}([1/6, 1/3, 1/2])
-@test isapprox(δ(1,s; hodge=DiagonalHodge()), [ 2.236  0  2.236;
-                                              -2.236  1  0;
-                                               0     -1 -2.236], atol=1e-3)
 @test isapprox(δ(1,s), [ 3.0  0  3.0;
                         -2.0  1 -1.0;
                          -1  -1 -2.0], atol=1e-3)

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -150,7 +150,9 @@ subdivide_duals!(s, Barycenter())
 @test volume(s, elementary_duals(s, V(1))) ≈ [1/12, 1/12]
 @test [sum(volume(s, elementary_duals(s, V(i)))) for i in 1:3] ≈ [1/6, 1/6, 1/6]
 @test ⋆(0,s) ≈ Diagonal([1/6, 1/6, 1/6])
-@test ⋆(1,s) ≈ Diagonal([√5/6, 1/6, √5/6])
+@test ⋆(1,s) ≈ [1/3 0.0 1/6;
+                0.0 1/6 0.0;
+                1/6 0.0 1/3]
 @test ⋆(s, VForm([1,2,3]))::DualForm{2} ≈ DualForm{2}([1/6, 1/3, 1/2])
 @test isapprox(δ(1,s), [ 2.236  0  2.236;
                         -2.236  1  0;
@@ -169,7 +171,9 @@ subdivide_duals!(s, Circumcenter())
 subdivide_duals!(s, Incenter())
 @test dual_point(s, triangle_center(s, 1)) ≈ Point2D(1/(2+√2), 1/(2+√2))
 @test isapprox(⋆(0,s), Diagonal([0.146, 0.177, 0.177]), atol=1e-3)
-@test isapprox(⋆(1,s), Diagonal([0.359, 0.207, 0.359]), atol=1e-3)
+@test isapprox(⋆(1,s), [0.293 0.000 0.207;
+                        0.000 0.207 0.000;
+                        0.207 0.000 0.293], atol=1e-3)
 @test isapprox(δ(1,s), [ 2.449  0      2.449;
                         -2.029  1.172  0;
                          0     -1.172 -2.029], atol=1e-3)


### PR DESCRIPTION
This PR provides an implementation of the hodge star on primal 1-forms presented in [Ayoub et al 2021](https://www.aimsciences.org/article/doi/10.3934/cpaa.2021062).