### PR TITLE
Lie derivative for dual 0,2-forms

### DIFF
--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -884,10 +884,20 @@ vector field.
 @inline lie_derivative_flat(n::Int, s::AbstractACSet, args...) =
   lie_derivative_flat(Val{n}, s, args...)
 
-function lie_derivative_flat(::Type{Val{n}}, s::AbstractACSet,
-                             X♭::AbstractVector, α::AbstractVector) where n
-  interior_product_flat(n+1, s, X♭, dual_derivative(n, s, α)) +
-    dual_derivative(n-1, s, interior_product_flat(n, s, X♭, α))
+function lie_derivative_flat(::Type{Val{0}}, s::AbstractACSet,
+                             X♭::AbstractVector, α::AbstractVector)
+  interior_product_flat(1, s, X♭, dual_derivative(0, s, α))
+end
+
+function lie_derivative_flat(::Type{Val{1}}, s::AbstractACSet,
+                             X♭::AbstractVector, α::AbstractVector)
+  interior_product_flat(2, s, X♭, dual_derivative(1, s, α)) +
+    dual_derivative(0, s, interior_product_flat(1, s, X♭, α))
+end
+
+function lie_derivative_flat(::Type{Val{2}}, s::AbstractACSet,
+                             X♭::AbstractVector, α::AbstractVector)
+  dual_derivative(1, s, interior_product_flat(2, s, X♭, α))
 end
 
 # Euclidean geometry

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -201,10 +201,23 @@ eform1, eform2 = EForm([1.5, 2, 2.5, 3, 3.5]), EForm([3, 7, 10, 11, 15])
 @test ∧(s, eform1, eform1)::TriForm ≈ TriForm([0, 0])
 @test ∧(s, eform1, eform2) ≈ -∧(s, eform2, eform1)
 
+# Lie derivative of flattened vector-field on dual 0-form
+X♭, α = EForm([1.5, 2, 2.5, 3, 3.5]), DualForm{0}([3, 7])
+@test ℒ(s, X♭, α) isa DualForm{0}
+@test length(lie_derivative_flat(0,s, X♭.data, α.data)) == 2
+
+# Lie derivative of flattened vector-field on dual 1-form
 X♭, α = EForm([1.5, 2, 2.5, 3, 3.5]), DualForm{1}([3, 7, 10, 11, 15])
 @test interior_product(s, X♭, α) isa DualForm{0}
 @test length(interior_product_flat(1,s, X♭.data, α.data)) == 2
 @test ℒ(s, X♭, α) isa DualForm{1}
 @test length(lie_derivative_flat(1,s, X♭.data, α.data)) == 5
+
+# Lie derivative of flattened vector-field on dual 2-form
+X♭, α = EForm([1.5, 2, 2.5, 3, 3.5]), DualForm{2}([3, 7, 10, 11])
+@test interior_product(s, X♭, α) isa DualForm{1}
+@test length(interior_product_flat(2,s, X♭.data, α.data)) == 5
+@test ℒ(s, X♭, α) isa DualForm{2}
+@test length(lie_derivative_flat(2,s, X♭.data, α.data)) == 4
 
 end


### PR DESCRIPTION
This PR addresses Issue #37 by creating three Lie Derivative functions for each of the dual forms.

Would it make more sense to add edge-case functions for the `dual_derivative`, `nsimplices`, and other functions that might receive dimension values out of range? This might reduce the amount of code redundancy here. 