### PR TITLE
ENH: Added 1D FreeExteriorCalculus Definition

### DIFF
--- a/src/ExteriorCalculus.jl
+++ b/src/ExteriorCalculus.jl
@@ -2,7 +2,8 @@ module ExteriorCalculus
 export Ob, Hom, dom, codom, compose, ⋅, id,
   otimes, ⊗, munit, braid, oplus, ⊕, mzero, swap, coproduct, ⊔,
   mcopy, Δ, delete, ◊, plus, +, zero, antipode,
-  MetricFreeExtCalc1D, MetricFreeExtCalc2D, ExtCalc1D, ExtCalc2D, FreeExtCalc2D,
+  MetricFreeExtCalc1D, MetricFreeExtCalc2D, ExtCalc1D, FreeExtCalc1D,
+  ExtCalc2D, FreeExtCalc2D,
   Space, Chain0, Chain1, Chain2, Form0, Form1, Form2,
   ∂₁, ∂₂, d₀, d₁, ∧₀₀, ∧₁₀, ∧₀₁, ∧₁₁, ∧₂₀, ∧₀₂, ι₁, ι₂, ℒ₀, ℒ₁, ℒ₂,
   DualForm0, DualForm1, DualForm2, ⋆₀, ⋆₁, ⋆₂, ⋆₀⁻¹, ⋆₁⁻¹, ⋆₂⁻¹,
@@ -171,6 +172,14 @@ end
   Δ₁(X::Space)::Hom(Form1(X),Form1(X))
   Δ₀(X) == d₀(X) ⋅ δ₁(X) ⊣ (X::Space)
   Δ₁(X) == δ₁(X) ⋅ d₀(X) ⊣ (X::Space)
+end
+
+@syntax FreeExtCalc1D{ObExpr,HomExpr,GATExpr} ExtCalc1D begin
+  compose(f::Hom, g::Hom) = associate_unit(new(f,g; strict=true), id)
+  oplus(A::Ob, B::Ob) = associate_unit(new(A,B), mzero)
+  oplus(f::Hom, g::Hom) = associate(new(f,g))
+  otimes(A::Ob, B::Ob) = associate_unit(new(A,B), munit)
+  otimes(f::Hom, g::Hom) = associate(new(f,g))
 end
 
 """ Theory of exterior calculus on 2D Riemannian manifold-like space.

--- a/test/ExteriorCalculus.jl
+++ b/test/ExteriorCalculus.jl
@@ -4,6 +4,37 @@ using Test
 using Catlab
 using CombinatorialSpaces.ExteriorCalculus
 
+############
+# 1D Tests #
+############
+
+@present Diffusion1DQuantities(FreeExtCalc1D) begin
+  X::Space
+  C::Hom(munit(), Form0(X))     # concentration
+  ϕ::Hom(munit(), DualForm0(X)) # negative diffusion flux
+  k::Hom(Form1(X), Form1(X))    # diffusivity (usually scalar multiplication)
+end
+
+@present Diffusion1D <: Diffusion1DQuantities begin
+  # Fick's first law
+  ϕ == C ⋅ d₀(X) ⋅ k ⋅ ⋆₁(X)
+  # Diffusion equation
+  C ⋅ ∂ₜ(Form0(X)) == ϕ ⋅ dual_d₀(X) ⋅ ⋆₀⁻¹(X)
+end
+
+@present Diffusion1D′ <: Diffusion1DQuantities begin
+  # Diffusion equation
+  C ⋅ ∂ₜ(Form0(X)) == C ⋅ d₀(X) ⋅ k ⋅ δ₁(X)
+end
+
+X, C, ϕ = Diffusion1D[:X], Diffusion1D[:C], Diffusion1D[:ϕ]
+@test codom(C) == Form0(X)
+@test codom(ϕ) == DualForm0(X)
+
+############
+# 2D Tests #
+############
+
 @present Diffusion2DQuantities(FreeExtCalc2D) begin
   X::Space
   C::Hom(munit(), Form0(X))     # concentration


### PR DESCRIPTION
This PR adds the definition of FreeExtCalc1D, following the pattern of the definition of FreeExtCalc2D. This is a pretty routine addition, just added in now to assist in defining 1D Decapodes.