### PR TITLE
Compatibility with Catlab v0.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Catlab = "0.13.1"
+Catlab = "0.14"
 FileIO = "^1"
 GeometryBasics = "0.3, 0.4"
 LazyArrays = "0.20, 0.21, 0.22"

--- a/src/CombinatorialMaps.jl
+++ b/src/CombinatorialMaps.jl
@@ -8,12 +8,12 @@ combinatorial objects describing embedded graphs.
 """
 module CombinatorialMaps
 export σ, α, ϕ, trace_vertices, trace_edges, trace_faces,
-  AbstractRotationGraph, RotationGraph, add_corolla!, pair_half_edges!,
-  AbstractRotationSystem, RotationSystem,
-  AbstractCombinatorialMap, CombinatorialMap
+  AbstractRotationGraph, RotationGraph, SchRotationGraph,
+  add_corolla!, pair_half_edges!,
+  AbstractRotationSystem, RotationSystem, SchRotationSystem,
+  AbstractCombinatorialMap, CombinatorialMap, SchCombinatorialMap
 
 using Catlab, Catlab.CategoricalAlgebra.CSets, Catlab.Graphs
-using Catlab.Graphs.BasicGraphs: TheoryHalfEdgeGraph
 using Catlab.Permutations: cycles
 
 # General properties
@@ -49,14 +49,14 @@ trace_faces(x::ACSet) = cycles(ϕ(x))
 # Rotation graphs
 #################
 
-@present TheoryRotationGraph <: TheoryHalfEdgeGraph begin
+@present SchRotationGraph <: SchHalfEdgeGraph begin
   σ::Hom(H,H)
 
   compose(σ, vertex) == vertex
 end
 
 @abstract_acset_type AbstractRotationGraph <: AbstractHalfEdgeGraph
-@acset_type RotationGraph(TheoryRotationGraph,
+@acset_type RotationGraph(SchRotationGraph,
                           index=[:vertex]) <: AbstractRotationGraph
 
 α(g::AbstractRotationGraph) = inv(g)
@@ -82,7 +82,7 @@ pair_half_edges!(g::AbstractRotationGraph, h, h′) =
 # Rotation systems
 ##################
 
-@present TheoryRotationSystem(FreeSchema) begin
+@present SchRotationSystem(FreeSchema) begin
   H::Ob
   σ::Hom(H,H)
   α::Hom(H,H)
@@ -91,7 +91,7 @@ pair_half_edges!(g::AbstractRotationGraph, h, h′) =
 end
 
 @abstract_acset_type AbstractRotationSystem
-@acset_type RotationSystem(TheoryRotationSystem) <: AbstractRotationSystem
+@acset_type RotationSystem(SchRotationSystem) <: AbstractRotationSystem
 
 # ϕ == (σ⋅α)⁻¹ == α⁻¹ ⋅ σ⁻¹
 ϕ(sys::AbstractRotationSystem) = sortperm(α(sys)[σ(sys)])
@@ -107,7 +107,7 @@ pair_half_edges!(sys::AbstractRotationSystem, h, h′) =
 # Combinatorial maps
 ####################
 
-@present TheoryHypermap(FreeSchema) begin
+@present SchHypermap(FreeSchema) begin
   H::Ob
   σ::Hom(H,H)
   α::Hom(H,H)
@@ -116,12 +116,12 @@ pair_half_edges!(sys::AbstractRotationSystem, h, h′) =
   compose(σ, α, ϕ) == id(H)
 end
 
-@present TheoryCombinatorialMap <: TheoryHypermap begin
+@present SchCombinatorialMap <: SchHypermap begin
   compose(α, α) == id(H)
 end
 
 @abstract_acset_type AbstractCombinatorialMap
-@acset_type CombinatorialMap(TheoryCombinatorialMap) <: AbstractCombinatorialMap
+@acset_type CombinatorialMap(SchCombinatorialMap) <: AbstractCombinatorialMap
 
 # TODO: What kind of interface should we have for maps and hypermaps?
 

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -9,10 +9,12 @@ module is Hirani's 2003 PhD thesis.
 module DiscreteExteriorCalculus
 export DualSimplex, DualV, DualE, DualTri, DualChain, DualForm,
   PrimalVectorField, DualVectorField,
-  AbstractDeltaDualComplex1D, DeltaDualComplex1D,
-  OrientedDeltaDualComplex1D, EmbeddedDeltaDualComplex1D,
-  AbstractDeltaDualComplex2D, DeltaDualComplex2D,
-  OrientedDeltaDualComplex2D, EmbeddedDeltaDualComplex2D,
+  AbstractDeltaDualComplex1D, DeltaDualComplex1D, SchDeltaDualComplex1D,
+  OrientedDeltaDualComplex1D, SchOrientedDeltaDualComplex1D,
+  EmbeddedDeltaDualComplex1D, SchEmbeddedDeltaDualComplex1D,
+  AbstractDeltaDualComplex2D, DeltaDualComplex2D, SchDeltaDualComplex2D,
+  OrientedDeltaDualComplex2D, SchOrientedDeltaDualComplex2D,
+  EmbeddedDeltaDualComplex2D, SchEmbeddedDeltaDualComplex2D,
   SimplexCenter, Barycenter, Circumcenter, Incenter, geometric_center,
   subsimplices, primal_vertex, elementary_duals, dual_boundary, dual_derivative,
   ⋆, hodge_star, inv_hodge_star, δ, codifferential, ∇², laplace_beltrami, Δ, laplace_de_rham,
@@ -28,11 +30,11 @@ using StaticArrays: @SVector, SVector
 
 using Catlab, Catlab.CategoricalAlgebra.CSets
 using Catlab.CategoricalAlgebra.FinSets: deleteat
-using Catlab.Graphs: HasGraph
 import Catlab.Theories: Δ
+
 using ..ArrayUtils, ..SimplicialSets
-using ..SimplicialSets: DeltaCategory1D, DeltaCategory2D, CayleyMengerDet,
-  operator_nz, ∂_nz, d_nz, cayley_menger, negate
+using ..SimplicialSets: CayleyMengerDet, operator_nz, ∂_nz, d_nz,
+  cayley_menger, negate
 import ..SimplicialSets: ∂, d, volume
 
 abstract type DiscreteFlat end
@@ -48,9 +50,9 @@ struct DiagonalHodge  <: DiscreteHodge end
 # 1D dual complex
 #################
 
-# Should be expressed using a coproduct of two copies of `DeltaCategory1D`.
+# Should be expressed using a coproduct of two copies of `SchDeltaSet1D`.
 
-@present SchemaDualComplex1D <: DeltaCategory1D begin
+@present SchDeltaDualComplex1D <: SchDeltaSet1D begin
   # Dual vertices and edges.
   (DualV, DualE)::Ob
   (D_∂v0, D_∂v1)::Hom(DualE, DualV)
@@ -86,7 +88,7 @@ end
 The data structure includes both the primal complex and the dual complex, as
 well as the mapping between them.
 """
-@acset_type DeltaDualComplex1D(SchemaDualComplex1D,
+@acset_type DeltaDualComplex1D(SchDeltaDualComplex1D,
   index=[:∂v0,:∂v1,:D_∂v0,:D_∂v1]) <: AbstractDeltaDualComplex1D
 
 """ Dual vertex corresponding to center of primal vertex.
@@ -120,7 +122,7 @@ end
 # 1D oriented dual complex
 #-------------------------
 
-@present SchemaOrientedDualComplex1D <: SchemaDualComplex1D begin
+@present SchOrientedDeltaDualComplex1D <: SchDeltaDualComplex1D begin
   Orientation::AttrType
   edge_orientation::Attr(E, Orientation)
   D_edge_orientation::Attr(DualE, Orientation)
@@ -128,7 +130,7 @@ end
 
 """ Oriented dual complex of an oriented 1D delta set.
 """
-@acset_type OrientedDeltaDualComplex1D(SchemaOrientedDualComplex1D,
+@acset_type OrientedDeltaDualComplex1D(SchOrientedDeltaDualComplex1D,
   index=[:∂v0,:∂v1,:D_∂v0,:D_∂v1]) <: AbstractDeltaDualComplex1D
 
 dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, x::Int) =
@@ -182,7 +184,7 @@ end
 # 1D embedded dual complex
 #-------------------------
 
-@present SchemaEmbeddedDualComplex1D <: SchemaOrientedDualComplex1D begin
+@present SchEmbeddedDeltaDualComplex1D <: SchOrientedDeltaDualComplex1D begin
   (Real, Point)::AttrType
   point::Attr(V, Point)
   length::Attr(E, Real)
@@ -195,7 +197,7 @@ end
 Although they are redundant information, the lengths of the primal and dual
 edges are precomputed and stored.
 """
-@acset_type EmbeddedDeltaDualComplex1D(SchemaEmbeddedDualComplex1D,
+@acset_type EmbeddedDeltaDualComplex1D(SchEmbeddedDeltaDualComplex1D,
   index=[:∂v0,:∂v1,:D_∂v0,:D_∂v1]) <: AbstractDeltaDualComplex1D
 
 """ Point associated with dual vertex of complex.
@@ -254,10 +256,10 @@ end
 # 2D dual complex
 #################
 
-# Should be expressed using a coproduct of two copies of `DeltaCategory2D` or
-# perhaps a pushout of `SchemaDualComplex2D` and `DeltaCategory1D`.
+# Should be expressed using a coproduct of two copies of `SchDeltaSet2D` or
+# perhaps a pushout of `SchDeltaDualComplex2D` and `SchDeltaSet1D`.
 
-@present SchemaDualComplex2D <: DeltaCategory2D begin
+@present SchDeltaDualComplex2D <: SchDeltaSet2D begin
   # Dual vertices, edges, and triangles.
   (DualV, DualE, DualTri)::Ob
   (D_∂v0, D_∂v1)::Hom(DualE, DualV)
@@ -280,7 +282,7 @@ end
 
 """ Dual complex of a two-dimensional delta set.
 """
-@acset_type DeltaDualComplex2D(SchemaDualComplex2D,
+@acset_type DeltaDualComplex2D(SchDeltaDualComplex2D,
   index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:D_∂v0,:D_∂v1,:D_∂e0,:D_∂e1,:D_∂e2]) <: AbstractDeltaDualComplex2D
 
 """ Dual vertex corresponding to center of primal triangle.
@@ -303,7 +305,7 @@ elementary_duals(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, t::Int) =
 # 2D oriented dual complex
 #-------------------------
 
-@present SchemaOrientedDualComplex2D <: SchemaDualComplex2D begin
+@present SchOrientedDeltaDualComplex2D <: SchDeltaDualComplex2D begin
   Orientation::AttrType
   edge_orientation::Attr(E, Orientation)
   tri_orientation::Attr(Tri, Orientation)
@@ -313,7 +315,7 @@ end
 
 """ Oriented dual complex of an oriented 2D delta set.
 """
-@acset_type OrientedDeltaDualComplex2D(SchemaOrientedDualComplex2D,
+@acset_type OrientedDeltaDualComplex2D(SchOrientedDeltaDualComplex2D,
   index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:D_∂v0,:D_∂v1,:D_∂e0,:D_∂e1,:D_∂e2]) <: AbstractDeltaDualComplex2D
 
 dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, x::Int) =
@@ -395,7 +397,7 @@ relative_sign(x::Bool, y::Bool) = (x && y) || (!x && !y)
 # 2D embedded dual complex
 #-------------------------
 
-@present SchemaEmbeddedDualComplex2D <: SchemaOrientedDualComplex2D begin
+@present SchEmbeddedDeltaDualComplex2D <: SchOrientedDeltaDualComplex2D begin
   (Real, Point)::AttrType
   point::Attr(V, Point)
   length::Attr(E, Real)
@@ -410,7 +412,7 @@ end
 Although they are redundant information, the lengths and areas of the
 primal/dual edges and triangles are precomputed and stored.
 """
-@acset_type EmbeddedDeltaDualComplex2D(SchemaEmbeddedDualComplex2D,
+@acset_type EmbeddedDeltaDualComplex2D(SchEmbeddedDeltaDualComplex2D,
   index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:D_∂v0,:D_∂v1,:D_∂e0,:D_∂e1,:D_∂e2]) <: AbstractDeltaDualComplex2D
 
 volume(::Type{Val{n}}, s::EmbeddedDeltaDualComplex2D, x) where n =
@@ -480,7 +482,7 @@ end
 
 function ∧(::Type{Tuple{1,1}}, s::HasDeltaSet2D, α, β, x::Int)
   # XXX: This calculation of the volume coefficients is awkward due to the
-  # design decision described in `SchemaDualComplex1D`.
+  # design decision described in `SchDeltaDualComplex1D`.
   dual_vs = vertex_center(s, triangle_vertices(s, x))
   dual_es = sort(SVector{6}(incident(s, triangle_center(s, x), :D_∂v0)),
                  by=e -> s[e,:D_∂v1] .== dual_vs, rev=true)[1:3]

--- a/src/ExteriorCalculus.jl
+++ b/src/ExteriorCalculus.jl
@@ -2,8 +2,8 @@ module ExteriorCalculus
 export Ob, Hom, dom, codom, compose, ⋅, id,
   otimes, ⊗, munit, braid, oplus, ⊕, mzero, swap, coproduct, ⊔,
   mcopy, Δ, delete, ◊, plus, +, zero, antipode,
-  MetricFreeExtCalc1D, MetricFreeExtCalc2D, ExtCalc1D, FreeExtCalc1D,
-  ExtCalc2D, FreeExtCalc2D,
+  ThMetricFreeExtCalc1D, ThExtCalc1D, FreeExtCalc1D,
+  ThMetricFreeExtCalc2D, ThExtCalc2D, FreeExtCalc2D,
   Space, Chain0, Chain1, Chain2, Form0, Form1, Form2,
   ∂₁, ∂₂, d₀, d₁, ∧₀₀, ∧₁₀, ∧₀₁, ∧₁₁, ∧₂₀, ∧₀₂, ι₁, ι₂, ℒ₀, ℒ₁, ℒ₂,
   DualForm0, DualForm1, DualForm2, ⋆₀, ⋆₁, ⋆₂, ⋆₀⁻¹, ⋆₁⁻¹, ⋆₂⁻¹,
@@ -24,7 +24,7 @@ additively (`SymmetricMonoidalCategoryAdditive` in Catlab).
 
 TODO: Migrate to `Catlab.Theories.MonoidalMultiple`.
 """
-@theory AdditiveMonoidalCategory{Ob,Hom} <: AdditiveCategory{Ob,Hom} begin
+@theory ThAdditiveMonoidalCategory{Ob,Hom} <: ThAdditiveCategory{Ob,Hom} begin
   # Tensor product.
   otimes(A::Ob, B::Ob)::Ob
   otimes(f::(A → B), g::(C → D))::((A ⊗ C) → (B ⊗ D)) ⊣
@@ -66,7 +66,7 @@ all assumed to be smoothly time-dependent and so are equipped with time
 derivative operators. Unlike in the space-time exterior calculus, we reserve the
 exterior calculus for the spatial dimensions and handle time separately.
 """
-@theory ManifoldCalculus{Ob,Hom,Space} <: AdditiveMonoidalCategory{Ob,Hom} begin
+@theory ThManifoldCalculus{Ob,Hom,Space} <: ThAdditiveMonoidalCategory{Ob,Hom} begin
   Space::TYPE
 
   # Coproduct of spaces. TODO: Is it worth fully axiomatizing?
@@ -83,7 +83,7 @@ end
 
 """ Theory of exterior calculus on 1-or-higher-dimensional manifold-like spaces.
 """
-@theory MetricFreeExtCalc1D₊{Ob,Hom,Space} <: ManifoldCalculus{Ob,Hom,Space} begin
+@theory ThMetricFreeExtCalc1D₊{Ob,Hom,Space} <: ThManifoldCalculus{Ob,Hom,Space} begin
   Chain0(X::Space)::Ob
   Chain1(X::Space)::Ob
   ∂₁(X::Space)::Hom(Chain1(X), Chain0(X))
@@ -109,13 +109,13 @@ end
 
 """ Theory of exterior caclulus on 1D manifold-like spaces.
 """
-@theory MetricFreeExtCalc1D{Ob,Hom,Space} <: MetricFreeExtCalc1D₊{Ob,Hom,Space} begin
+@theory ThMetricFreeExtCalc1D{Ob,Hom,Space} <: ThMetricFreeExtCalc1D₊{Ob,Hom,Space} begin
   ℒ₁(X) == ι₁(X) ⋅ d₀(X) ⊣ (X::Space)
 end
 
 """ Theory of exterior calculus on 2-or-higher-dimensional manifold-like spaces.
 """
-@theory MetricFreeExtCalc2D₊{Ob,Hom,Space} <: MetricFreeExtCalc1D₊{Ob,Hom,Space} begin
+@theory ThMetricFreeExtCalc2D₊{Ob,Hom,Space} <: ThMetricFreeExtCalc1D₊{Ob,Hom,Space} begin
   Chain2(X::Space)::Ob
   ∂₂(X::Space)::Hom(Chain2(X), Chain1(X))
   ∂₂(X) ⋅ ∂₁(X) == zero(Chain2(X), Chain0(X)) ⊣ (X::Space)
@@ -139,7 +139,7 @@ end
 
 """ Theory of exterior calculus on 2D manifold-like spaces.
 """
-@theory MetricFreeExtCalc2D{Ob,Hom,Space} <: MetricFreeExtCalc2D₊{Ob,Hom,Space} begin
+@theory ThMetricFreeExtCalc2D{Ob,Hom,Space} <: ThMetricFreeExtCalc2D₊{Ob,Hom,Space} begin
   ℒ₂(X) == ι₂(X) ⋅ d₁(X) ⊣ (X::Space)
 end
 
@@ -148,7 +148,7 @@ end
 
 """ Theory of exterior calculus on 1D Riemannian manifold-like space.
 """
-@theory ExtCalc1D{Ob,Hom,Space} <: MetricFreeExtCalc1D{Ob,Hom,Space} begin
+@theory ThExtCalc1D{Ob,Hom,Space} <: ThMetricFreeExtCalc1D{Ob,Hom,Space} begin
   DualForm0(X::Space)::Ob
   DualForm1(X::Space)::Ob
   DualForm0(X⊔Y) == DualForm0(X)⊕DualForm0(Y) ⊣ (X::Space, Y::Space)
@@ -174,7 +174,7 @@ end
   Δ₁(X) == δ₁(X) ⋅ d₀(X) ⊣ (X::Space)
 end
 
-@syntax FreeExtCalc1D{ObExpr,HomExpr,GATExpr} ExtCalc1D begin
+@syntax FreeExtCalc1D{ObExpr,HomExpr,GATExpr} ThExtCalc1D begin
   compose(f::Hom, g::Hom) = associate_unit(new(f,g; strict=true), id)
   oplus(A::Ob, B::Ob) = associate_unit(new(A,B), mzero)
   oplus(f::Hom, g::Hom) = associate(new(f,g))
@@ -184,7 +184,7 @@ end
 
 """ Theory of exterior calculus on 2D Riemannian manifold-like space.
 """
-@theory ExtCalc2D{Ob,Hom,Space} <: MetricFreeExtCalc2D{Ob,Hom,Space} begin
+@theory ThExtCalc2D{Ob,Hom,Space} <: ThMetricFreeExtCalc2D{Ob,Hom,Space} begin
   DualForm0(X::Space)::Ob
   DualForm1(X::Space)::Ob
   DualForm2(X::Space)::Ob
@@ -223,7 +223,7 @@ end
   Δ₂(X) == δ₂(X) ⋅ d₁(X) ⊣ (X::Space)
 end
 
-@syntax FreeExtCalc2D{ObExpr,HomExpr,GATExpr} ExtCalc2D begin
+@syntax FreeExtCalc2D{ObExpr,HomExpr,GATExpr} ThExtCalc2D begin
   compose(f::Hom, g::Hom) = associate_unit(new(f,g; strict=true), id)
   oplus(A::Ob, B::Ob) = associate_unit(new(A,B), mzero)
   oplus(f::Hom, g::Hom) = associate(new(f,g))

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -14,10 +14,13 @@ exterior derivative) operators. For additional operators, see the
 """
 module SimplicialSets
 export Simplex, V, E, Tri, SimplexChain, VChain, EChain, TriChain,
-  SimplexForm, VForm, EForm, TriForm,
-  HasDeltaSet, HasDeltaSet1D, HasDeltaSet2D,
-  AbstractDeltaSet1D, DeltaSet1D, OrientedDeltaSet1D, EmbeddedDeltaSet1D,
-  AbstractDeltaSet2D, DeltaSet2D, OrientedDeltaSet2D, EmbeddedDeltaSet2D,
+  SimplexForm, VForm, EForm, TriForm, HasDeltaSet,
+  HasDeltaSet1D, AbstractDeltaSet1D, DeltaSet1D, SchDeltaSet1D,
+  OrientedDeltaSet1D, SchOrientedDeltaSet1D,
+  EmbeddedDeltaSet1D, SchEmbeddedDeltaSet1D,
+  HasDeltaSet2D, AbstractDeltaSet2D, DeltaSet2D, SchDeltaSet2D,
+  OrientedDeltaSet2D, SchOrientedDeltaSet2D,
+  EmbeddedDeltaSet2D, SchEmbeddedDeltaSet2D,
   ∂, boundary, coface, d, coboundary, exterior_derivative,
   simplices, nsimplices, point, volume,
   orientation, set_orientation!, orient!, orient_component!,
@@ -39,7 +42,7 @@ using ..ArrayUtils
 # 0-D simplicial sets
 #####################
 
-@present DeltaCategory0D(FreeSchema) begin
+@present SchDeltaSet0D(FreeSchema) begin
   V::Ob
 end
 
@@ -61,7 +64,7 @@ add_vertices!(s::HasDeltaSet, n::Int; kw...) = add_parts!(s, :V, n; kw...)
 # 1D simplicial sets
 ####################
 
-@present DeltaCategory1D <: DeltaCategory0D begin
+@present SchDeltaSet1D <: SchDeltaSet0D begin
   E::Ob
   (∂v0, ∂v1)::Hom(E, V) # (∂₁(0), ∂₁(1))
 end
@@ -81,7 +84,7 @@ The source and target of an edge can be accessed using the face maps [`∂`](@re
 (simplicial terminology) or `src` and `tgt` maps (graph-theoretic terminology).
 More generally, this type implements the graphs interface in `Catlab.Graphs`.
 """
-@acset_type DeltaSet1D(DeltaCategory1D, index=[:∂v0,:∂v1]) <: AbstractDeltaSet1D
+@acset_type DeltaSet1D(SchDeltaSet1D, index=[:∂v0,:∂v1]) <: AbstractDeltaSet1D
 
 edges(s::HasDeltaSet1D) = parts(s, :E)
 edges(s::HasDeltaSet1D, src::Int, tgt::Int) =
@@ -130,7 +133,7 @@ end
 # 1D oriented simplicial sets
 #----------------------------
 
-@present OrientedDeltaSchema1D <: DeltaCategory1D begin
+@present SchOrientedDeltaSet1D <: SchDeltaSet1D begin
   Orientation::AttrType
   edge_orientation::Attr(E,Orientation)
 end
@@ -140,7 +143,7 @@ end
 Edges are oriented from source to target when `edge_orientation` is
 true/positive and from target to source when it is false/negative.
 """
-@acset_type OrientedDeltaSet1D(OrientedDeltaSchema1D,
+@acset_type OrientedDeltaSet1D(SchOrientedDeltaSet1D,
                                index=[:∂v0,:∂v1]) <: AbstractDeltaSet1D
 
 orientation(::Type{Val{1}}, s::HasDeltaSet1D, args...) =
@@ -160,14 +163,14 @@ end
 # 1D embedded simplicial sets
 #----------------------------
 
-@present EmbeddedDeltaSchema1D <: OrientedDeltaSchema1D begin
+@present SchEmbeddedDeltaSet1D <: SchOrientedDeltaSet1D begin
   Point::AttrType
   point::Attr(V, Point)
 end
 
 """ A one-dimensional, embedded, oriented delta set.
 """
-@acset_type EmbeddedDeltaSet1D(EmbeddedDeltaSchema1D,
+@acset_type EmbeddedDeltaSet1D(SchEmbeddedDeltaSet1D,
                                index=[:∂v0,:∂v1]) <: AbstractDeltaSet1D
 
 """ Point associated with vertex of complex.
@@ -184,7 +187,7 @@ volume(::Type{Val{1}}, s::HasDeltaSet1D, e::Int, ::CayleyMengerDet) =
 # 2D simplicial sets
 ####################
 
-@present DeltaCategory2D <: DeltaCategory1D begin
+@present SchDeltaSet2D <: SchDeltaSet1D begin
   Tri::Ob
   (∂e0, ∂e1, ∂e2)::Hom(Tri,E) # (∂₂(0), ∂₂(1), ∂₂(2))
 
@@ -214,7 +217,7 @@ higher-dimensional link or morphism, going from two edges in sequence (which
 might be called `src2_first` and `src2_last`) to a transitive edge (say `tgt2`).
 This is the shape of the binary composition operation in a category.
 """
-@acset_type DeltaSet2D(DeltaCategory2D,
+@acset_type DeltaSet2D(SchDeltaSet2D,
                        index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2]) <: AbstractDeltaSet2D
 
 triangles(s::HasDeltaSet2D) = parts(s, :Tri)
@@ -285,7 +288,7 @@ end
 # 2D oriented simplicial sets
 #----------------------------
 
-@present OrientedDeltaSchema2D <: DeltaCategory2D begin
+@present SchOrientedDeltaSet2D <: SchDeltaSet2D begin
   Orientation::AttrType
   edge_orientation::Attr(E,Orientation)
   tri_orientation::Attr(Tri,Orientation)
@@ -296,7 +299,7 @@ end
 Triangles are ordered in the cyclic order ``(0,1,2)`` when `tri_orientation` is
 true/positive and in the reverse order when it is false/negative.
 """
-@acset_type OrientedDeltaSet2D(OrientedDeltaSchema2D,
+@acset_type OrientedDeltaSet2D(SchOrientedDeltaSet2D,
                                index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2]) <: AbstractDeltaSet2D
 
 orientation(::Type{Val{2}}, s::HasDeltaSet2D, args...) =
@@ -319,14 +322,14 @@ end
 # 2D embedded simplicial sets
 #----------------------------
 
-@present EmbeddedDeltaSchema2D <: OrientedDeltaSchema2D begin
+@present SchEmbeddedDeltaSet2D <: SchOrientedDeltaSet2D begin
   Point::AttrType
   point::Attr(V, Point)
 end
 
 """ A two-dimensional, embedded, oriented delta set.
 """
-@acset_type EmbeddedDeltaSet2D(EmbeddedDeltaSchema2D,
+@acset_type EmbeddedDeltaSet2D(SchEmbeddedDeltaSet2D,
                                index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2]) <: AbstractDeltaSet2D
 
 volume(::Type{Val{n}}, s::EmbeddedDeltaSet2D, x) where n =


### PR DESCRIPTION
The schemas for delta sets and their dual complexes are now exported following the new naming convention.