### PR TITLE
Support 3D Simplicial Sets

### DIFF
--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -1,6 +1,3 @@
-# TODO: Document where appropriate where the compositional numbering vs.
-# simplicial identity numbering scheme is in use in this API.
-
 """ Simplicial sets in one, two, and three dimensions.
 
 For the time being, this module provides data structures only for [delta
@@ -250,13 +247,12 @@ function triangles(s::HasDeltaSet2D, v₀::Int, v₁::Int, v₂::Int)
   # to refactor around multiple dispatch, or always data-migrate to
   # SchDeltaSet2D.
 
-  # TODO: Is there a better idiom for `isempty(x) && return []`?
   e₀s = coface(1,0,s,v₂) ∩ coface(1,1,s,v₁)
-  isempty(e₀s) && return []
+  isempty(e₀s) && return Int[]
   e₁s = coface(1,0,s,v₂) ∩ coface(1,1,s,v₀)
-  isempty(e₁s) && return []
+  isempty(e₁s) && return Int[]
   e₂s = coface(1,0,s,v₁) ∩ coface(1,1,s,v₀)
-  isempty(e₂s) && return []
+  isempty(e₂s) && return Int[]
   coface(2,0,s,e₀s...) ∩ coface(2,1,s,e₁s...) ∩ coface(2,2,s,e₂s...)
 end
 
@@ -395,7 +391,6 @@ volume(::Type{Val{2}}, s::HasDeltaSet2D, t::Int, ::CayleyMengerDet) =
   Tet::Ob
   (∂t0, ∂t1, ∂t2, ∂t3)::Hom(Tet,Tri) # (∂₃(0), ∂₃(1), ∂₃(2), ∂₃(3))
 
-  # TODO: Is there a test that accesses SchDeltaSet3D.equations?
   # Simplicial identities.
   ∂t3 ⋅ ∂e2 == ∂t2 ⋅ ∂e2
   ∂t3 ⋅ ∂e1 == ∂t1 ⋅ ∂e2
@@ -446,8 +441,6 @@ end
 This accessor assumes that the simplicial identities hold.
 """
 function tetrahedron_edges(s::HasDeltaSet3D, t...)
-  # TODO: Is there an index selection that would result in fewer cache misses,
-  # that still respects this vertex ordering?
   SVector(s[s[t..., :∂t0], :∂e0], # e₀
           s[s[t..., :∂t0], :∂e1], # e₁
           s[s[t..., :∂t0], :∂e2], # e₂
@@ -461,8 +454,6 @@ end
 This accessor assumes that the simplicial identities hold.
 """
 function tetrahedron_vertices(s::HasDeltaSet3D, t...)
-  # TODO: Is there an index selection that would result in fewer cache misses,
-  # that still respects this vertex ordering?
   SVector(s[s[s[t..., :∂t2], :∂e2], :∂v1], # v₀
           s[s[s[t..., :∂t2], :∂e2], :∂v0], # v₁
           s[s[s[t..., :∂t0], :∂e0], :∂v1], # v₂
@@ -470,9 +461,6 @@ function tetrahedron_vertices(s::HasDeltaSet3D, t...)
 end
 
 """ Add a tetrahedron (3-simplex) to a simplicial set, given its boundary triangles.
-
-# TODO: Add the order of the boundary triangles.
-In the arguments to this function, the boundary triangles have the order ....
 
 !!! warning
 
@@ -490,10 +478,6 @@ If a needed triangle between two vertices exists, it is reused (hence the "gluin
 otherwise, it is created. Necessary 1-simplices are likewise glued.
 """
 function glue_tetrahedron!(s::HasDeltaSet3D, v₀::Int, v₁::Int, v₂::Int, v₃::Int; kw...)
-  # Note: You could write glue_tetrahedron! assuming instead get_triangle!
-  # takes edges as input. But, get_edge! would be called at the surface level
-  # (here), and again inside of glue_triangle!.
-
   # Note: There is a redundancy here in that the e.g. the first get_triangle!
   # guarantees that certain edges are already added, so some later calls to
   # get_edge! inside the following calls to get_triangle! don't actually need to
@@ -529,10 +513,6 @@ end
 end
 
 """ A three-dimensional oriented delta set.
-
-# TODO: Where must the following condition be enforced in code?
-Tetrahedra are ordered in an even permutation of ``(0,1,2,3)`` when
-`tet_orientation` is true/positive and in odd order when it is false/negative.
 """
 @acset_type OrientedDeltaSet3D(SchOrientedDeltaSet3D,
                                index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:∂t0,:∂t1,:∂t2,:∂t3]) <: AbstractDeltaSet3D

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -37,7 +37,7 @@ export Simplex, V, E, Tri, Tet, SimplexChain, VChain, EChain, TriChain, TetChain
   add_triangle!, glue_triangle!, glue_sorted_triangle!,
   tetrahedron_triangles, tetrahedron_edges, tetrahedron_vertices, ntetrahedra,
   tetrahedra, add_tetrahedron!, glue_tetrahedron!, glue_sorted_tetrahedron!,
-  is_manifold_like, nonfaces
+  is_manifold_like, nonboundaries
 
 using LinearAlgebra: det
 using SparseArrays
@@ -870,27 +870,27 @@ function is_manifold_like(s::HasDeltaSet, ::Type{Simplex{n}}) where n
   true
 end
 
-""" Find the simplices which are not the face of another.
+""" Find the simplices which are not a face of another.
 
 For an n-D oriented delta set, return a vector of 0 through n-1 chains
 consisting of the simplices that are not the face of another. Note that since
 n-simplices in an n-D oriented delta set are never the face of an (n+1)-simplex,
 these are excluded.
-"""
-nonfaces(s::AbstractDeltaSet1D) = nonfaces(s, E)
-nonfaces(s::AbstractDeltaSet2D) = nonfaces(s, Tri)
-nonfaces(s::AbstractDeltaSet3D) = nonfaces(s, Tet)
 
-function nonfaces(s::HasDeltaSet, ::Type{Simplex{n}}) where n
-  nonfaces = [SimplexChain{i}([]) for i in 0:n-1]
-  for k in 0:n-1
-    # The yth k-simplex c is not a face of an (k+1)-simplex if the yth column of
-    # the exterior derivative matrix is all zeros.
-    for (y, c) in enumerate(eachcol(d(k,s)))
-      isempty(nonzeros(c)) && push!(nonfaces[k+1].data, y)
-    end
+We choose the term "nonboundaries" so as not to be confused with the term
+"nonface", defined as those faces that are not in a simplical complex, whose
+corresponding monomials are the basis of the Stanley-Reisner ideal.
+"""
+nonboundaries(s::AbstractDeltaSet1D) = nonboundaries(s, E)
+nonboundaries(s::AbstractDeltaSet2D) = nonboundaries(s, Tri)
+nonboundaries(s::AbstractDeltaSet3D) = nonboundaries(s, Tet)
+
+function nonboundaries(s::HasDeltaSet, ::Type{Simplex{n}}) where n
+  # The yth k-simplex c is not a face of an (k+1)-simplex if the yth column of
+  # the exterior derivative matrix is all zeros.
+  map(0:n-1) do k
+    SimplexChain{k}(findall(iszero, eachcol(d(k,s))))
   end
-  nonfaces
 end
 
 end

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -34,7 +34,7 @@ export Simplex, V, E, Tri, Tet, SimplexChain, VChain, EChain, TriChain, TetChain
   add_triangle!, glue_triangle!, glue_sorted_triangle!,
   tetrahedron_triangles, tetrahedron_edges, tetrahedron_vertices, ntetrahedra,
   tetrahedra, add_tetrahedron!, glue_tetrahedron!, glue_sorted_tetrahedron!,
-  is_manifold_like, nonboundaries
+  is_manifold_like, nonboundaries, glue_sorted_tet_cube!
 
 using LinearAlgebra: det
 using SparseArrays
@@ -500,6 +500,29 @@ end
 function glue_sorted_tetrahedron!(s::HasDeltaSet3D, v₀::Int, v₁::Int, v₂::Int, v₃::Int; kw...)
   v₀, v₁, v₂, v₃ = sort(SVector(v₀, v₁, v₂, v₃))
   glue_tetrahedron!(s, v₀, v₁, v₂, v₃; kw...)
+end
+
+""" Glue a tetrahedralized cube onto a simplicial set, respecting the order of the vertices.
+
+After sorting, the faces of the cube are:
+1 5-4 0,
+1 2-6 5,
+1 2-3 0,
+7 4-0 3,
+7 3-2 6,
+7 6-5 4,
+For each face, the diagonal edge is between those vertices connected by a dash.
+The internal diagonal is between vertices 1 and 7.
+"""
+function glue_sorted_tet_cube!(s::HasDeltaSet3D, v₀::Int, v₁::Int, v₂::Int,
+  v₃::Int, v₄::Int, v₅::Int, v₆::Int, v₇::Int; kw...)
+  v₀, v₁, v₂, v₃, v₄, v₅, v₆, v₇ = sort(SVector(v₀, v₁, v₂, v₃, v₄, v₅, v₆, v₇))
+  glue_tetrahedron!(s, v₀, v₁, v₃, v₇; kw...),
+  glue_tetrahedron!(s, v₁, v₂, v₃, v₇; kw...),
+  glue_tetrahedron!(s, v₀, v₁, v₄, v₇; kw...),
+  glue_tetrahedron!(s, v₁, v₂, v₆, v₇; kw...),
+  glue_tetrahedron!(s, v₁, v₄, v₅, v₇; kw...),
+  glue_tetrahedron!(s, v₁, v₅, v₆, v₇; kw...)
 end
 
 # 3D oriented simplicial sets

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -336,6 +336,37 @@ end
 @test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
 @test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
 
+# Five tetrahedra example from Letniowski 1992, as given by Blessent Table 3.3b.
+s = EmbeddedDeltaSet3D{Bool,Point3D}()
+add_vertices!(s, 6, point=[
+  # See table 3.3a "Nodal coordinates"
+  Point3D(-2, -2,   0.5),
+  Point3D( 0, -2,   0.1),
+  Point3D(-2,  0,   0.1),
+  Point3D( 0,  0.1, 0),
+  Point3D(-2, -2,  -0.25),
+  Point3D(-2, -2,   1.5)])
+# See Table 3.3b "Connectivity list for Letniowski's example"
+glue_sorted_tetrahedron!(s, 1, 2, 4, 6)
+glue_sorted_tetrahedron!(s, 1, 3, 4, 6)
+glue_sorted_tetrahedron!(s, 1, 2, 3, 5)
+glue_sorted_tetrahedron!(s, 2, 3, 4, 5)
+glue_sorted_tetrahedron!(s, 1, 2, 3, 4)
+@test ntetrahedra(s) == 5
+@test tetrahedra(s) == 1:5
+@test is_semi_simplicial(s, 2)
+@test is_semi_simplicial(s, 3)
+s[:edge_orientation] = true
+s[:tri_orientation] = true
+s[:tet_orientation] = true
+orient!(s)
+@test is_manifold_like(s)
+for i in 1:3
+  @test isempty(nonfaces(s)[i])
+end
+@test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
+@test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
+
 # Euclidean geometry
 ####################
 

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -156,6 +156,81 @@ add_vertices!(s, 3, point=[Point3D(1,0,0), Point3D(0,1,0), Point3D(0,0,1)])
 glue_triangle!(s, 1, 2, 3, tri_orientation=true)
 @test volume(s, Tri(1)) ≈ sqrt(3)/2
 
+# 3D simplicial sets
+####################
+
+s = DeltaSet3D()
+add_vertices!(s, 4)
+glue_tetrahedron!(s, 1, 2, 3, 4)
+@test is_semi_simplicial(s, 3)
+@test ntetrahedra(s) == 1
+# TODO: Check this map test.
+@test map(i -> ∂(2, i, s, 1), (0,1,2)) == (2,3,1)
+@test tetrahedron_vertices(s, 1) == [1,2,3,4]
+
+s′ = DeltaSet3D()
+add_vertices!(s′, 4)
+glue_sorted_tetrahedron!(s′, 2, 4, 3, 1)
+@test s′ == s
+
+# Two tetrahedra forming a square pyramid.
+s = DeltaSet3D()
+add_vertices!(s, 5)
+glue_tetrahedron!(s, 1, 2, 3, 5)
+glue_tetrahedron!(s, 2, 3, 4, 5)
+@test ntetrahedra(s) == 2
+@test tetrahedra(s) == 1:2
+@test ntriangles(s) == 7
+@test triangles(s) == 1:7
+@test ne(s) == 9
+# TODO: Check this edge test.
+@test sort(map(Pair, src(s), tgt(s))) == [1=>2, 1=>3, 1=>4, 2=>3, 4=>3]
+
+# 3D oriented simplicial sets
+#----------------------------
+
+# Tetrahedron with orientation.
+s = OrientedDeltaSet3D{Bool}()
+add_vertices!(s, 4)
+glue_tetrahedron!(s, 1, 2, 3, 4)
+s[:edge_orientation] = [true, false, true, false, true, false]
+s[:tri_orientation] = [true, false, true, false]
+@test orient_component!(s, 1, true)
+@test orientation(s, Tet(1)) == true
+# TODO: Check this boundary by hand.
+#@test ∂(2, s, 1) == [1,1,1]
+# TODO: Check this exterior derivative by hand.
+#@test d(1, s, [17,19,23,29,31,37]) == [w,x,y,z] # ==
+# TODO: Check this exterior derivative by hand.
+#@test d(2, s, [3,5,17,257]) == [-242] # == [3-5+17-257]
+
+# Two tetrahedra forming a square pyramid with orientation.
+s = OrientedDeltaSet3D{Bool}()
+add_vertices!(s, 5)
+glue_tetrahedron!(s, 1, 2, 3, 5)
+glue_tetrahedron!(s, 2, 3, 4, 5)
+s[:edge_orientation] = true
+s[:tri_orientation] = true
+@test orient!(s)
+@test orientation(s, Tet(1:2)) == trues(2)
+# TODO: Work out these computations by hand.
+#@test ∂(2, s, 1) == [...]
+#@test ∂(3, s, 1) == [...]
+#@test ∂(s, TetChain([1,1]))::TriChain == TriChain([...])
+#@test d(s, TriForm([45,3,34,0]))::TetForm == TetForm([...]) # == [...]
+#@test d(s, TriForm([45,3,34,17])) == TetForm([...]) # == [...]
+@test d(1, s) == ∂(2, s)'
+@test d(2, s) == ∂(3, s)'
+
+# 3D embedded simplicial sets
+#----------------------------
+
+# Regular tetrahedron with edge length 2√2 in ℝ³.
+s = EmbeddedDeltaSet3D{Bool,Point3D}()
+add_vertices!(s, 4, point=[Point3D(1,1,1), Point3D(1,-1,-1), Point3D(-1,1,-1), Point3D(-1,-1,1)])
+glue_tetrahedron!(s, 1, 2, 3, 4, tri_orientation=true)
+@test volume(s, Tet(1)) ≈ (2*sqrt(2))^3/(6*sqrt(2)) # 𝓁³/(6√2)
+
 # Euclidean geometry
 ####################
 

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -44,6 +44,8 @@ add_vertices!(s, 4)
 add_edges!(s, [1,2,3], [2,3,4], edge_orientation=[true,false,true])
 @test ∂(1, s, 1) == [-1,1,0,0]
 @test ∂(1, s, 2) == [0,1,-1,0]
+@test is_manifold_like(s)
+@test isempty(only(nonfaces(s)))
 
 # Boundary operator, dense vectors.
 vvec = ∂(1, s, 1, Vector{Int})
@@ -146,6 +148,9 @@ s[:edge_orientation] = true
 @test d(s, EForm([45,3,34,0,0]))::TriForm == TriForm([14, 34]) # == [45+3-34, 34]
 @test d(s, EForm([45,3,34,17,5])) == TriForm([14, 46]) # == [45+3-34, 34+17-5]
 @test d(1, s) == ∂(2, s)'
+@test is_manifold_like(s)
+@test isempty(nonfaces(s)[1])
+@test isempty(nonfaces(s)[2])
 
 # 2D embedded simplicial sets
 #----------------------------
@@ -214,7 +219,7 @@ glue_tetrahedron!(s, 2, 6, 7, 8)
 @test is_semi_simplicial(s, 3)
 for t in tetrahedra(s)
   @test sort(unique(reduce(vcat, edge_vertices(s, tetrahedron_edges(s,t))))) ==
-  tetrahedron_vertices(s,t)
+    tetrahedron_vertices(s,t)
 end
 
 # 3D oriented simplicial sets
@@ -246,10 +251,12 @@ s[:tri_orientation] = true
 @test ∂(2, s, 1) == sparsevec([1,2,3], [1,1,-1], 9)
 @test ∂(3, s, 1) == sparsevec([1,2,3,4], [1,-1,1,-1], 7)
 @test ∂(s, TetChain([1,1]))::TriChain == TriChain([0,-1,1,-1,-1,1,1])
-@test d(s, TriForm([1,10,100,1000,10000,100000,1000000]))::TetForm == TetForm([-909,1089999]) # == [...]
+@test d(s, TriForm([1,10,100,1000,10000,100000,1000000]))::TetForm == TetForm([-909,1089999])
 @test d(0, s) == ∂(1, s)'
 @test d(1, s) == ∂(2, s)'
 @test d(2, s) == ∂(3, s)'
+@test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
+@test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
 
 # 3D embedded simplicial sets
 #----------------------------
@@ -263,7 +270,7 @@ orient!(s)
 regular_tetrahedron_volume(len) = len^3/(6√2)
 @test volume(s, Tet(1)) ≈ regular_tetrahedron_volume(2√2)
 
-# Six tetrahedra forming a cube.
+# Six tetrahedra of equal volume forming a cube with edge length 2.
 s = EmbeddedDeltaSet3D{Bool,Point3D}()
 add_vertices!(s, 8, point=[
   Point3D(-1,1,1), Point3D(1,1,1), Point3D(1,-1,1), Point3D(-1,-1,1),
@@ -288,6 +295,12 @@ orient!(s)
 for t in tetrahedra(s)
   @test volume(s, Tet(t)) ≈ 8/6
 end
+@test is_manifold_like(s)
+for i in 1:3
+  @test isempty(nonfaces(s)[i])
+end
+@test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
+@test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
 
 # Euclidean geometry
 ####################

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -39,7 +39,6 @@ add_sorted_edges!(s, [2,4], [3,3])
 # 1D oriented simplicial sets
 #----------------------------
 
-using Test
 s = OrientedDeltaSet1D{Bool}()
 add_vertices!(s, 4)
 add_edges!(s, [1,2,3], [2,3,4], edge_orientation=[true,false,true])
@@ -197,10 +196,10 @@ glue_tetrahedron!(s, 2, 3, 4, 5)
 @test is_semi_simplicial(s, 3)
 @test tetrahedron_vertices(s, 1) == [1,2,3,5]
 @test tetrahedron_vertices(s, 2) == [2,3,4,5]
-@test sort(unique(reduce(vcat, edge_vertices(s, tetrahedron_edges(s,1))))) ==
-  tetrahedron_vertices(s,1)
-@test sort(unique(reduce(vcat, edge_vertices(s, tetrahedron_edges(s,2))))) ==
-  tetrahedron_vertices(s,2)
+tetrahedron_to_edges_to_vertices(s,t) = sort(unique(reduce(vcat, edge_vertices(s, tetrahedron_edges(s,t)))))
+for t in tetrahedra(s)
+  @test tetrahedron_to_edges_to_vertices(s,t) == tetrahedron_vertices(s,t)
+end
 
 # Six tetrahedra forming a cube.
 s = DeltaSet3D()
@@ -219,8 +218,7 @@ glue_tetrahedron!(s, 2, 6, 7, 8)
 @test is_semi_simplicial(s, 2)
 @test is_semi_simplicial(s, 3)
 for t in tetrahedra(s)
-  @test sort(unique(reduce(vcat, edge_vertices(s, tetrahedron_edges(s,t))))) ==
-    tetrahedron_vertices(s,t)
+  @test tetrahedron_to_edges_to_vertices(s,t) == tetrahedron_vertices(s,t)
 end
 
 # 3D oriented simplicial sets
@@ -256,8 +254,8 @@ s[:tri_orientation] = true
 @test d(0, s) == ∂(1, s)'
 @test d(1, s) == ∂(2, s)'
 @test d(2, s) == ∂(3, s)'
-@test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
-@test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
+@test d(1, s) * d(0, s) * vertices(s) == zeros(ntriangles(s))
+@test d(2, s) * d(1, s) * edges(s) == zeros(ntetrahedra(s))
 
 # 3D embedded simplicial sets
 #----------------------------
@@ -300,15 +298,16 @@ end
 for i in 1:3
   @test isempty(nonboundaries(s)[i])
 end
-@test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
-@test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
+@test d(1, s) * d(0, s) * vertices(s) == zeros(ntriangles(s))
+@test d(2, s) * d(1, s) * edges(s) == zeros(ntetrahedra(s))
 added_edge = add_edge!(s, 1,2, edge_orientation=true)
 @test nonboundaries(s)[2] == EChain([added_edge])
 added_triangle = add_triangle!(s, 1,2,3, tri_orientation=true)
 @test nonboundaries(s)[3] == TriChain([added_triangle])
 
 # Six tetrahedra of equal volume forming a cube with edge length 1.
-# The connectivity is that of Blessent's 2009 thesis, Figure 3.2.
+# The connectivity is that of Blessent's 2009 thesis "Integration of 3D
+# Geologicial and Numerical Models Based on Tetrahedral Meshes...", Figure 3.2.
 s = EmbeddedDeltaSet3D{Bool,Point3D}()
 add_vertices!(s, 8, point=[
   Point3D(0,1,0), Point3D(0,0,0), Point3D(1,1,0), Point3D(1,0,0),
@@ -338,13 +337,13 @@ end
 for i in 1:3
   @test isempty(nonboundaries(s)[i])
 end
-@test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
-@test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
+@test d(1, s) * d(0, s) * vertices(s) == zeros(ntriangles(s))
+@test d(2, s) * d(1, s) * edges(s) == zeros(ntetrahedra(s))
 
 # Five tetrahedra example from Letniowski 1992, as given by Blessent Table 3.3b.
 s = EmbeddedDeltaSet3D{Bool,Point3D}()
 add_vertices!(s, 6, point=[
-  # See table 3.3a "Nodal coordinates"
+  # See Table 3.3a "Nodal coordinates"
   Point3D(-2, -2,   0.5),
   Point3D( 0, -2,   0.1),
   Point3D(-2,  0,   0.1),
@@ -369,8 +368,8 @@ orient!(s)
 for i in 1:3
   @test isempty(nonboundaries(s)[i])
 end
-@test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
-@test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
+@test d(1, s) * d(0, s) * vertices(s) == zeros(ntriangles(s))
+@test d(2, s) * d(1, s) * edges(s) == zeros(ntetrahedra(s))
 
 # Euclidean geometry
 ####################

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -39,13 +39,14 @@ add_sorted_edges!(s, [2,4], [3,3])
 # 1D oriented simplicial sets
 #----------------------------
 
+using Test
 s = OrientedDeltaSet1D{Bool}()
 add_vertices!(s, 4)
 add_edges!(s, [1,2,3], [2,3,4], edge_orientation=[true,false,true])
 @test ∂(1, s, 1) == [-1,1,0,0]
 @test ∂(1, s, 2) == [0,1,-1,0]
 @test is_manifold_like(s)
-@test isempty(only(nonfaces(s)))
+@test isempty(only(nonboundaries(s)))
 
 # Boundary operator, dense vectors.
 vvec = ∂(1, s, 1, Vector{Int})
@@ -149,8 +150,8 @@ s[:edge_orientation] = true
 @test d(s, EForm([45,3,34,17,5])) == TriForm([14, 46]) # == [45+3-34, 34+17-5]
 @test d(1, s) == ∂(2, s)'
 @test is_manifold_like(s)
-@test isempty(nonfaces(s)[1])
-@test isempty(nonfaces(s)[2])
+@test isempty(nonboundaries(s)[1])
+@test isempty(nonboundaries(s)[2])
 
 # 2D embedded simplicial sets
 #----------------------------
@@ -297,10 +298,14 @@ for t in tetrahedra(s)
 end
 @test is_manifold_like(s)
 for i in 1:3
-  @test isempty(nonfaces(s)[i])
+  @test isempty(nonboundaries(s)[i])
 end
 @test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
 @test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
+added_edge = add_edge!(s, 1,2, edge_orientation=true)
+@test nonboundaries(s)[2] == EChain([added_edge])
+added_triangle = add_triangle!(s, 1,2,3, tri_orientation=true)
+@test nonboundaries(s)[3] == TriChain([added_triangle])
 
 # Six tetrahedra of equal volume forming a cube with edge length 1.
 # The connectivity is that of Blessent's 2009 thesis, Figure 3.2.
@@ -331,7 +336,7 @@ for t in tetrahedra(s)
 end
 @test is_manifold_like(s)
 for i in 1:3
-  @test isempty(nonfaces(s)[i])
+  @test isempty(nonboundaries(s)[i])
 end
 @test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
 @test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
@@ -362,7 +367,7 @@ s[:tet_orientation] = true
 orient!(s)
 @test is_manifold_like(s)
 for i in 1:3
-  @test isempty(nonfaces(s)[i])
+  @test isempty(nonboundaries(s)[i])
 end
 @test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
 @test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -302,6 +302,40 @@ end
 @test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
 @test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
 
+# Six tetrahedra of equal volume forming a cube with edge length 1.
+# The connectivity is that of Blessent's 2009 thesis, Figure 3.2.
+s = EmbeddedDeltaSet3D{Bool,Point3D}()
+add_vertices!(s, 8, point=[
+  Point3D(0,1,0), Point3D(0,0,0), Point3D(1,1,0), Point3D(1,0,0),
+  Point3D(0,1,1), Point3D(0,0,1), Point3D(1,1,1), Point3D(1,0,1)])
+# See Table 3.1 "Mesh connectivity".
+glue_sorted_tetrahedron!(s, 3, 5, 4, 2)
+glue_sorted_tetrahedron!(s, 7, 6, 8, 4)
+glue_sorted_tetrahedron!(s, 5, 6, 7, 4)
+glue_sorted_tetrahedron!(s, 3, 5, 7, 4)
+glue_sorted_tetrahedron!(s, 5, 6, 4, 2)
+glue_sorted_tetrahedron!(s, 1, 5, 3, 2)
+@test ntetrahedra(s) == 6
+@test tetrahedra(s) == 1:6
+@test ntriangles(s) == 18
+@test triangles(s) == 1:18 # (2 * num cube faces) + (2 * num "cuts" into cube)
+@test ne(s) == 19 # (num cube edges) + (num cube faces) + (internal diagonal)
+@test is_semi_simplicial(s, 2)
+@test is_semi_simplicial(s, 3)
+s[:edge_orientation] = true
+s[:tri_orientation] = true
+s[:tet_orientation] = true
+orient!(s)
+for t in tetrahedra(s)
+  @test volume(s, Tet(t)) ≈ 1/6
+end
+@test is_manifold_like(s)
+for i in 1:3
+  @test isempty(nonfaces(s)[i])
+end
+@test d(1, s) * d(0, s) * collect(vertices(s)) == zeros(ntriangles(s))
+@test d(2, s) * d(1, s) * collect(edges(s)) == zeros(ntetrahedra(s))
+
 # Euclidean geometry
 ####################
 


### PR DESCRIPTION
This PR is to track progress on implementing 3D (semi-)simplicial sets in SimplicialSets.jl.

Currently, CombinatorialSpaces.jl supports only 1D and 2D simplicial sets. Although some methods are implemented for arbitrary dimension, such as `orient!`, these methods cannot take advantage of this flexibility due to the lack of higher dimensional simplicial complexes stored as ACSets.

Although there may be some benefits to refactoring SimplicialSets.jl to support arbitrary ND, the diminishing utility for dimensions beyond 3 or 4 for physical applications justifies focusing on a hand-written implementation of 3D simplicial sets for the time being. This is not to say that there is no utility to such an approach. One advantage is that of long-term maintainability at the expense of a larger up-front engineering effort.