### PR TITLE
Move sign inside wedge pd, and solve for pressure in euler

### DIFF
--- a/docs/src/discrete_exterior_calculus.md
+++ b/docs/src/discrete_exterior_calculus.md
@@ -3,6 +3,6 @@
 ## API docs
 
 ```@autodocs
-Modules = [ DiscreteExteriorCalculus ]
+Modules = [ DiscreteExteriorCalculus, FastDEC ]
 Private = false
 ```

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -1340,7 +1340,7 @@ Make a dual 1-form primal by chaining ♭ᵈᵖ♯ᵈᵈ.
 This returns a matrix which can be multiplied by a dual 1-form.
 See also [`♭♯`](@ref).
 """
-♭♯_mat(s::HasDeltaSet) = ♭_mat(s) * ♯_mat(s, LLSDDSharp())
+♭♯_mat(s::HasDeltaSet) = only.(♭_mat(s) * ♯_mat(s, LLSDDSharp()))
 
 """    ♭♯(s::HasDeltaSet, α::SimplexForm{1})
 
@@ -1349,7 +1349,7 @@ Make a dual 1-form primal by chaining ♭ᵈᵖ♯ᵈᵈ.
 This returns the given dual 1-form as a primal 1-form.
 See also [`♭♯_mat`](@ref).
 """
-♭♯(s::HasDeltaSet, α::SimplexForm{1}) = only.(♭♯_mat(s) * α)
+♭♯(s::HasDeltaSet, α::SimplexForm{1}) = ♭♯_mat(s) * α
 
 """ Alias for the flat-sharp dual-to-primal interpolation operator [`♭♯`](@ref).
 """

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -15,8 +15,7 @@ export dec_boundary, dec_differential, dec_dual_derivative, dec_hodge_star, dec_
        dec_wedge_product_dd,
        Δᵈ
 
-"""
-    dec_p_wedge_product(::Type{Tuple{0,1}}, sd::EmbeddedDeltaDualComplex1D)
+"""    dec_p_wedge_product(::Type{Tuple{0,1}}, sd::EmbeddedDeltaDualComplex1D)
 
 Precomputes values for the wedge product between a 0 and 1-form.
 The values are to be fed into the wedge_terms parameter for the computational "c" varient. 
@@ -27,8 +26,7 @@ function dec_p_wedge_product(::Type{Tuple{0,1}}, sd::EmbeddedDeltaDualComplex1D)
     return (hcat(convert(Vector{Int32}, sd[:∂v0])::Vector{Int32}, convert(Vector{Int32}, sd[:∂v1])::Vector{Int32}), simplices(1, sd))
 end
 
-"""
-    dec_p_wedge_product(::Type{Tuple{0,1}}, sd::EmbeddedDeltaDualComplex2D)
+"""    dec_p_wedge_product(::Type{Tuple{0,1}}, sd::EmbeddedDeltaDualComplex2D)
 
 Precomputes values for the wedge product between a 0 and 1-form.
 The values are to be fed into the wedge_terms parameter for the computational "c" varient. 
@@ -41,8 +39,7 @@ end
 
 # XXX: This assumes that the dual vertice on an edge is always the midpoint
 # TODO: Add options to change 0.5 to a different float
-"""
-    dec_c_wedge_product!(::Type{Tuple{0,1}}, wedge_terms, f, α, val_pack)
+"""    dec_c_wedge_product!(::Type{Tuple{0,1}}, wedge_terms, f, α, val_pack)
 
 Computes the wedge product between a 0 and 1-form.
 Use the precomputational "p" varient for the wedge_terms parameter. 
@@ -59,8 +56,7 @@ function dec_c_wedge_product!(::Type{Tuple{0,1}}, wedge_terms, f, α, val_pack)
     return wedge_terms
 end
 
-"""
-    dec_p_wedge_product(::Type{Tuple{0,2}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
+"""    dec_p_wedge_product(::Type{Tuple{0,2}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
 
 Precomputes values for the wedge product between a 0 and 2-form.
 The values are to be fed into the wedge_terms parameter for the computational "c" varient. 
@@ -101,8 +97,7 @@ function dec_p_wedge_product(::Type{Tuple{0,2}}, sd::EmbeddedDeltaDualComplex2D{
     return (primal_vertices, coeffs, simples)
 end
 
-"""
-    dec_c_wedge_product!(::Type{Tuple{0,2}}, wedge_terms, f, α, val_pack)
+"""    dec_c_wedge_product!(::Type{Tuple{0,2}}, wedge_terms, f, α, val_pack)
 
 Computes the wedge product between a 0 and 2-form.
 Use the precomputational "p" varient for the wedge_terms parameter. 
@@ -120,8 +115,7 @@ function dec_c_wedge_product!(::Type{Tuple{0,2}}, wedge_terms, f, α, val_pack)
     return wedge_terms
 end
 
-"""
-    dec_p_wedge_product(::Type{Tuple{1,1}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
+"""    dec_p_wedge_product(::Type{Tuple{1,1}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
 
 Precomputes values for the wedge product between a 1 and 1-form.
 The values are to be fed into the wedge_terms parameter for the computational "c" varient. 
@@ -154,8 +148,7 @@ function dec_p_wedge_product(::Type{Tuple{1,1}}, sd::EmbeddedDeltaDualComplex2D{
     return (e, coeffs, simples)
 end
 
-"""
-    dec_c_wedge_product!(::Type{Tuple{1,1}}, wedge_terms, f, α, val_pack)
+"""    dec_c_wedge_product!(::Type{Tuple{1,1}}, wedge_terms, f, α, val_pack)
 
 Computes the wedge product between a 1 and 1-form.
 Use the precomputational "p" varient for the wedge_terms parameter. 
@@ -180,8 +173,7 @@ function dec_c_wedge_product!(::Type{Tuple{1,1}}, wedge_terms, α, β, val_pack)
     return wedge_terms
 end
 
-"""
-    dec_c_wedge_product(::Type{Tuple{m,n}}, α, β, val_pack) where {m,n}
+"""    dec_c_wedge_product(::Type{Tuple{m,n}}, α, β, val_pack) where {m,n}
 
 Computes the wedge product between two forms.
 Use the precomputational "p" varient for the wedge_terms parameter. 
@@ -196,8 +188,7 @@ end
 
 dec_wedge_product(m::Int, n::Int, sd::HasDeltaSet) = dec_wedge_product(Tuple{m,n}, sd::HasDeltaSet)
 
-"""
-    dec_wedge_product(::Type{Tuple{0,0}}, sd::HasDeltaSet)
+"""    dec_wedge_product(::Type{Tuple{0,0}}, sd::HasDeltaSet)
 
 Returns a function that computes the wedge product between two 0-forms.
 """
@@ -205,8 +196,7 @@ function dec_wedge_product(::Type{Tuple{0,0}}, sd::HasDeltaSet)
     (f, g) -> f .* g
 end
 
-"""
-    dec_wedge_product(::Type{Tuple{k,0}}, sd::HasDeltaSet) where {k}
+"""    dec_wedge_product(::Type{Tuple{k,0}}, sd::HasDeltaSet) where {k}
 
 Returns a function that computes wedge product between a k and a 0-form.
 """
@@ -215,8 +205,7 @@ function dec_wedge_product(::Type{Tuple{k,0}}, sd::HasDeltaSet) where {k}
     (α, g) -> dec_c_wedge_product(Tuple{0,k}, g, α, val_pack)
 end
 
-"""
-    dec_wedge_product(::Type{Tuple{0,k}}, sd::HasDeltaSet) where {k}
+"""    dec_wedge_product(::Type{Tuple{0,k}}, sd::HasDeltaSet) where {k}
 
 Returns a function that computes the wedge product between a 0 and a k-form.
 """
@@ -225,8 +214,7 @@ function dec_wedge_product(::Type{Tuple{0,k}}, sd::HasDeltaSet) where {k}
     (f, β) -> dec_c_wedge_product(Tuple{0,k}, f, β, val_pack)
 end
 
-"""
-    dec_wedge_product(::Type{Tuple{1,1}}, sd::HasDeltaSet2D)
+"""    dec_wedge_product(::Type{Tuple{1,1}}, sd::HasDeltaSet2D)
 
 Returns a function that computes the wedge product between a 1 and a 1-form.
 """
@@ -235,8 +223,7 @@ function dec_wedge_product(::Type{Tuple{1,1}}, sd::HasDeltaSet2D)
     (α, β) -> dec_c_wedge_product(Tuple{1,1}, α, β, val_pack)
 end
 
-"""
-    function wedge_dd_01_mat(sd::HasDeltaSet)
+"""    function wedge_dd_01_mat(sd::HasDeltaSet)
 
 Returns a matrix that can be multiplied to a dual 0-form, before being
 elementwise-multiplied by a dual 1-form, encoding the wedge product.
@@ -255,8 +242,7 @@ function wedge_dd_01_mat(sd::HasDeltaSet)
   m
 end
 
-"""
-    dec_wedge_product_dd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
+"""    dec_wedge_product_dd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
 
 Returns a cached function that computes the wedge product between a dual
 0-form and a dual 1-form.
@@ -266,8 +252,7 @@ function dec_wedge_product_dd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
   (f,g) -> (m * f) .* g
 end
 
-"""
-    dec_wedge_product_dd(::Type{Tuple{1,0}}, sd::HasDeltaSet)
+"""    dec_wedge_product_dd(::Type{Tuple{1,0}}, sd::HasDeltaSet)
 
 Returns a cached function that computes the wedge product between a dual
 1-form and a dual 0-form.
@@ -277,8 +262,7 @@ function dec_wedge_product_dd(::Type{Tuple{1,0}}, sd::HasDeltaSet)
   (f,g) -> f .* (m * g)
 end
 
-"""
-    function wedge_pd_01_mat(sd::HasDeltaSet)
+"""    function wedge_pd_01_mat(sd::HasDeltaSet)
 
 Returns a matrix that can be multiplied to a primal 0-form, before being
 elementwise-multiplied by a dual 1-form, encoding the wedge product.
@@ -306,8 +290,7 @@ function wedge_pd_01_mat(sd::HasDeltaSet)
   m
 end
 
-"""
-    dec_wedge_product_pd(::Type{Tuple{1,0}}, sd::HasDeltaSet)
+"""    dec_wedge_product_dp(::Type{Tuple{1,0}}, sd::HasDeltaSet)
 
 Returns a cached function that computes the wedge product between a dual
 1-form and a primal 0-form.
@@ -320,8 +303,7 @@ function dec_wedge_product_dp(::Type{Tuple{1,0}}, sd::HasDeltaSet)
   (f,g) -> f .* (m * g)
 end
 
-"""
-    function dec_wedge_product_pd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
+"""    function dec_wedge_product_pd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
 
 Returns a cached function that computes the wedge product between a primal
 0-form and a dual 1-form.
@@ -334,33 +316,31 @@ function dec_wedge_product_pd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
   (g,f) -> (m * g) .* f
 end
 
-"""
-    dec_wedge_product_pd(::Type{Tuple{1,1}}, sd::HasDeltaSet)
+"""    dec_wedge_product_pd(::Type{Tuple{1,1}}, sd::HasDeltaSet)
 
 Returns a cached function that computes the wedge product between a primal
 1-form and a dual 1-form.
 """
 function dec_wedge_product_pd(::Type{Tuple{1,1}}, sd::HasDeltaSet)
   ♭♯_m = ♭♯_mat(sd)
-  ♭♯_cached(x) = only.(♭♯_m * x)
   Λ_cached = dec_wedge_product(Tuple{1, 1}, sd)
-  (f, g) -> sign(2,sd) .* Λ_cached(f, ♭♯_cached(g))
+  (f, g) -> sign(2,sd) .* Λ_cached(f, ♭♯_m * g)
 end
 
-"""
-    dec_wedge_product_dp(::Type{Tuple{1,1}}, sd::HasDeltaSet)
+"""    dec_wedge_product_dp(::Type{Tuple{1,1}}, sd::HasDeltaSet)
 
 Returns a cached function that computes the wedge product between a dual 1-form
 and a primal 1-form.
 """
 function dec_wedge_product_dp(::Type{Tuple{1,1}}, sd::HasDeltaSet)
   ♭♯_m = ♭♯_mat(sd)
-  ♭♯_cached(x) = only.(♭♯_m * x)
   Λ_cached = dec_wedge_product(Tuple{1, 1}, sd)
-  (f, g) -> sign(2,sd) .* Λ_cached(♭♯_cached(f), g)
+  (f, g) -> sign(2,sd) .* Λ_cached(♭♯_m * f, g)
 end
 
-""" Wedge product of a primal 1-form and a dual 1-form.
+"""    ∧(s::HasDeltaSet, α::SimplexForm{1}, β::DualForm{1})
+
+Wedge product of a primal 1-form and a dual 1-form.
 
 Chain the musical isomorphisms to interpolate the dual 1-form to a primal
 1-form, using the linear least squares ♯. Then use the CombinatorialSpaces
@@ -369,7 +349,9 @@ version of the Hirani primal-primal weddge.
 ∧(s::HasDeltaSet, α::SimplexForm{1}, β::DualForm{1}) =
   dec_wedge_product_pd(Tuple{1,1}, s)(α, β)
 
-""" Wedge product of a dual 1-form and a primal 1-form.
+"""    ∧(s::HasDeltaSet, α::DualForm{1}, β::SimplexForm{1})
+
+Wedge product of a dual 1-form and a primal 1-form.
 
 Chain the musical isomorphisms to interpolate the dual 1-form to a primal
 1-form. Then use the CombinatorialSpaces version of the Hirani primal-primal

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -685,7 +685,7 @@ function interior_product_dd(::Type{Tuple{1,2}}, s::SimplicialSets.HasDeltaSet)
   hs1 = dec_hodge_star(Val{1}, s, GeometricHodge())
   ♭♯_m = ♭♯_mat(s)
   Λ01_m = wedge_pd_01_mat(s)
-  (f,g) -> hs1 * only.(♭♯_m * ((Λ01_m * ihs0 * g) .* f))
+  (f,g) -> hs1 * ♭♯_m * ((Λ01_m * ihs0 * g) .* f)
 end
 
 """    function ℒ_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -344,7 +344,7 @@ function dec_wedge_product_pd(::Type{Tuple{1,1}}, sd::HasDeltaSet)
   ♭♯_m = ♭♯_mat(sd)
   ♭♯_cached(x) = only.(♭♯_m * x)
   Λ_cached = dec_wedge_product(Tuple{1, 1}, sd)
-  (f, g) -> Λ_cached(f, ♭♯_cached(g))
+  (f, g) -> sign(2,sd) .* Λ_cached(f, ♭♯_cached(g))
 end
 
 """
@@ -357,7 +357,7 @@ function dec_wedge_product_dp(::Type{Tuple{1,1}}, sd::HasDeltaSet)
   ♭♯_m = ♭♯_mat(sd)
   ♭♯_cached(x) = only.(♭♯_m * x)
   Λ_cached = dec_wedge_product(Tuple{1, 1}, sd)
-  (f, g) -> Λ_cached(♭♯_cached(f), g)
+  (f, g) -> sign(2,sd) .* Λ_cached(♭♯_cached(f), g)
 end
 
 """ Wedge product of a primal 1-form and a dual 1-form.
@@ -711,7 +711,6 @@ end
 Given a dual 1-form and a dual 1-form, return their lie derivative as a dual 1-form.
 """
 function ℒ_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
-  # TODO: Check signs.
   # ℒ := -diuv - iduv
   d0 = dec_dual_derivative(0, s)
   d1 = dec_dual_derivative(1, s)

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -652,9 +652,10 @@ for (primal_s,s) in flat_meshes
   u_star = hodge_star(1,s) * u
 
   @test all(isapprox.(
-    sign(2,s) .* hodge_star(2,s) * ∧(s, SimplexForm{1}(u), DualForm{1}(u_star)),
+    dec_hodge_star(2,s) * ∧(s, SimplexForm{1}(u), DualForm{1}(u_star)),
     ff_gg,
     atol=1e-10))
 end
 
 end
+

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -352,7 +352,7 @@ function euler_equation_test(X♯, sd)
   u = hodge_star(1,sd) * eval_constant_primal_form(sd, X♯)
 
   # Recall Euler's Equation:
-  # ∂ₜu = ℒᵤu - 0.5dιᵤu  - 1/ρdp + b.
+  # ∂ₜu = -ℒᵤu + 0.5dιᵤu  - 1/ρdp + b.
   # We expect for a uniform flow then that ∂ₜu = 0.
   # We will not explicitly set boundary conditions for this test.
 


### PR DESCRIPTION
Previously, we were multiplying by the sign of a dual 2-form after performing the primal-dual 1-1 wedge product at the outermost "test level." It makes sense to curry the sign-accommodation code inside these wedge product operators themselves.

This PR contains two further improvements to the tests: solving for pressure in the test for Euler's equations, and a standalone interior product dual-dual test set.