### PR TITLE
Factorize and solve the Laplacian on the GPU

### DIFF
--- a/test/OperatorsCUDA.jl
+++ b/test/OperatorsCUDA.jl
@@ -2,6 +2,7 @@ module TestOperatorsCUDA
 
 using CUDA
 using CUDA.CUSPARSE
+using CUDA.CUSOLVER
 using Catlab
 using CombinatorialSpaces
 using GeometryBasics: Point2, Point3
@@ -208,6 +209,12 @@ end
     # Comparisons of the solutions:
     resid_resid = Array(Δ0*y) .- Δ0_cpu*y_cpu
     RMS = sqrt(mean(resid_resid.^2))
+
+    # CUDA's native qr facorization-solve.
+    using CUDA.CUSOLVER: SparseQR, spqr_solve
+    Δ0_CSR = CuSparseMatrixCSR(Δ0_cpu)
+    Δ0_QR = SparseQR(Δ0_CSR)
+    spqr_solve(Δ0_QR, w, y)
   end
 end
 


### PR DESCRIPTION
PR #75 added GPU support to CombinatorialSpaces.jl via the CUDA.jl API.

Currently, we directly offer GPU support for the classic DEC primitive operators: $d, \star$, and $\wedge^{pp}$. And Decapodes.jl is able to automatically create bindings for higher-order operators on the GPU - such as the Laplacian - by expanding their definitions - e.g. $d\star d\star$ - and pre-multiplying those matrices. The branch `llm/cuda-wedge-music` is adding GPU support for $\wedge_{10}^{p d}, \wedge^{dp}_{01}$, and the interpolating musical operator $\flat\sharp$. These operators are implemented as matrix-multiplications are relatively straight-forward to port to the GPU.

However, some operators - such as the geometric Hodge star for 1-forms - are instead implemented by solving a matrix implementing that operator. $\star^{-1}$ was implemented by using `gmres` from Krylov.jl, and performantly solves this system, since it is "mostly" diagonal.

However, when we need to solve the heat equation by solving the sparse $\Delta_0$ matrix, `gmres` is not able to provide adequate performance. Further, even the factorization of this matrix on the GPU is prohibitively-expensive.

So, we need to provide a canonical way of solving this problem quickly in the CombinatorialSpaces library. The current prototype factors the matrix on the CPU, sends its components to the GPU, and in-houses an LU-solve.

We are also experimenting with approximations to the Laplacian on well-structured meshes that can be exploited for superior factorizations.