### PR TITLE
Upstream the averaging operator

### DIFF
--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -23,7 +23,8 @@ export DualSimplex, DualV, DualE, DualTri, DualChain, DualForm,
   vertex_center, edge_center, triangle_center, dual_triangle_vertices, dual_edge_vertices,
   dual_point, dual_volume, subdivide_duals!, DiagonalHodge, GeometricHodge,
   subdivide, PPSharp, AltPPSharp, DesbrunSharp, LLSDDSharp, de_sign,
-  ♭♯, ♭♯_mat, flat_sharp, flat_sharp_mat
+  ♭♯, ♭♯_mat, flat_sharp, flat_sharp_mat,
+  avg₀₁, avg_01
 
 import Base: ndims
 import Base: *
@@ -1473,6 +1474,28 @@ const flat_sharp = ♭♯
 """ Alias for the flat-sharp dual-to-primal interpolation matrix [`♭♯_mat`](@ref).
 """
 const flat_sharp_mat = ♭♯_mat
+
+""" Averaging matrix from 0-forms to 1-forms.
+
+Given a 0-form, this matrix computes a 1-form by taking the mean of value stored on the faces of each edge.
+
+This matrix can be used to implement a wedge product: `(avg₀₁(s)*X) .* Y` where `X` is a 0-form and `Y` a 1-form, assuming the center of an edge is halfway between its endpoints.
+"""
+function avg₀₁(s::HasDeltaSet)
+  I = Vector{Int64}()
+  J = Vector{Int64}()
+  V = Vector{Float64}()
+  for e in 1:ne(s)
+    append!(J, [s[e,:∂v0],s[e,:∂v1]])
+    append!(I, [e,e])
+    append!(V, [0.5, 0.5])
+  end
+  sparse(I,J,V)
+end
+
+""" Alias for the averaging matrix [`avg₀₁`](@ref).
+"""
+const avg_01 = avg₀₁
 
 """ Wedge product of discrete forms.
 

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -23,8 +23,7 @@ export DualSimplex, DualV, DualE, DualTri, DualChain, DualForm,
   vertex_center, edge_center, triangle_center, dual_triangle_vertices, dual_edge_vertices,
   dual_point, dual_volume, subdivide_duals!, DiagonalHodge, GeometricHodge,
   subdivide, PPSharp, AltPPSharp, DesbrunSharp, LLSDDSharp, de_sign,
-  ♭♯, ♭♯_mat, flat_sharp, flat_sharp_mat,
-  avg₀₁, avg_01, avg₀₁_mat, avg_01_mat
+  ♭♯, ♭♯_mat, flat_sharp, flat_sharp_mat
 
 import Base: ndims
 import Base: *
@@ -1474,46 +1473,6 @@ const flat_sharp = ♭♯
 """ Alias for the flat-sharp dual-to-primal interpolation matrix [`♭♯_mat`](@ref).
 """
 const flat_sharp_mat = ♭♯_mat
-
-function avg₀₁_mat_helper(s::HasDeltaSet, V::AbstractVector)
-  I = Vector{Int32}()
-  J = Vector{Int32}()
-  for e in 1:ne(s)
-    append!(J, [s[e,:∂v0],s[e,:∂v1]])
-    append!(I, [e,e])
-    append!(V, [0.5, 0.5])
-  end
-  sparse(I,J,V)
-end
-
-""" Averaging matrix from 0-forms to 1-forms.
-
-Given a 0-form, this matrix computes a 1-form by taking the mean of value stored on the faces of each edge.
-
-This matrix can be used to implement a wedge product: `(avg₀₁(s)*X) .* Y` where `X` is a 0-form and `Y` a 1-form, assuming the center of an edge is halfway between its endpoints.
-
-See also [`avg₀₁`](@ref).
-"""
-avg₀₁_mat(s::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type =
-  avg₀₁_mat_helper(s, Vector{float_type}())
-avg₀₁_mat(s::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p) where float_type =
-  avg₀₁_mat_helper(s, Vector{float_type}())
-
-"""    avg₀₁(s::HasDeltaSet, α::SimplexForm{0})
-
-Turn a 0-form into a 1-form by averaging data stored on the face of an edge.
-
-See also [`avg₀₁_mat`](@ref).
-"""
-avg₀₁(s::HasDeltaSet, α::SimplexForm{0}) = avg₀₁_mat(s) * α
-
-""" Alias for the averaging operator [`avg₀₁`](@ref).
-"""
-const avg_01 = avg₀₁
-
-""" Alias for the averaging matrix [`avg₀₁_mat`](@ref).
-"""
-const avg_01_mat = avg₀₁_mat
 
 """ Wedge product of discrete forms.
 

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -24,7 +24,7 @@ export DualSimplex, DualV, DualE, DualTri, DualChain, DualForm,
   dual_point, dual_volume, subdivide_duals!, DiagonalHodge, GeometricHodge,
   subdivide, PPSharp, AltPPSharp, DesbrunSharp, LLSDDSharp, de_sign,
   ♭♯, ♭♯_mat, flat_sharp, flat_sharp_mat,
-  avg₀₁, avg_01
+  avg₀₁, avg_01, avg₀₁_mat, avg_01_mat
 
 import Base: ndims
 import Base: *
@@ -1480,8 +1480,10 @@ const flat_sharp_mat = ♭♯_mat
 Given a 0-form, this matrix computes a 1-form by taking the mean of value stored on the faces of each edge.
 
 This matrix can be used to implement a wedge product: `(avg₀₁(s)*X) .* Y` where `X` is a 0-form and `Y` a 1-form, assuming the center of an edge is halfway between its endpoints.
+
+See also [`avg₀₁`](@ref).
 """
-function avg₀₁(s::HasDeltaSet)
+function avg₀₁_mat(s::HasDeltaSet)
   I = Vector{Int64}()
   J = Vector{Int64}()
   V = Vector{Float64}()
@@ -1493,9 +1495,21 @@ function avg₀₁(s::HasDeltaSet)
   sparse(I,J,V)
 end
 
-""" Alias for the averaging matrix [`avg₀₁`](@ref).
+"""    avg₀₁(s::HasDeltaSet, α::SimplexForm{0})
+
+Turn a 0-form into a 1-form by averaging data stored on the face of an edge.
+
+See also [`avg₀₁_mat`](@ref).
+"""
+avg₀₁(s::HasDeltaSet, α::SimplexForm{0}) = avg₀₁_mat(s) * α
+
+""" Alias for the averaging operator [`avg₀₁`](@ref).
 """
 const avg_01 = avg₀₁
+
+""" Alias for the averaging matrix [`avg₀₁_mat`](@ref).
+"""
+const avg_01_mat = avg₀₁_mat
 
 """ Wedge product of discrete forms.
 

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -1475,6 +1475,17 @@ const flat_sharp = ♭♯
 """
 const flat_sharp_mat = ♭♯_mat
 
+function avg₀₁_mat_helper(s::HasDeltaSet, V::AbstractVector)
+  I = Vector{Int32}()
+  J = Vector{Int32}()
+  for e in 1:ne(s)
+    append!(J, [s[e,:∂v0],s[e,:∂v1]])
+    append!(I, [e,e])
+    append!(V, [0.5, 0.5])
+  end
+  sparse(I,J,V)
+end
+
 """ Averaging matrix from 0-forms to 1-forms.
 
 Given a 0-form, this matrix computes a 1-form by taking the mean of value stored on the faces of each edge.
@@ -1483,17 +1494,10 @@ This matrix can be used to implement a wedge product: `(avg₀₁(s)*X) .* Y` wh
 
 See also [`avg₀₁`](@ref).
 """
-function avg₀₁_mat(s::HasDeltaSet)
-  I = Vector{Int64}()
-  J = Vector{Int64}()
-  V = Vector{Float64}()
-  for e in 1:ne(s)
-    append!(J, [s[e,:∂v0],s[e,:∂v1]])
-    append!(I, [e,e])
-    append!(V, [0.5, 0.5])
-  end
-  sparse(I,J,V)
-end
+avg₀₁_mat(s::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type =
+  avg₀₁_mat_helper(s, Vector{float_type}())
+avg₀₁_mat(s::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p) where float_type =
+  avg₀₁_mat_helper(s, Vector{float_type}())
 
 """    avg₀₁(s::HasDeltaSet, α::SimplexForm{0})
 

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -489,6 +489,15 @@ for k = 0:2
   @test all(∧(s, α, βᵏ) .≈ βᵏ)
 end
 
+# 2 ∧ (1dx + 1dy) = 2dx + 2dy
+two = fill(2.0, nv(s))
+onedx_onedy = eval_constant_form(s, @SVector [1.0,1.0,0.0])
+# Test that the averaging matrix can compute a wedge product.
+avg_mat = avg₀₁(s)
+twodx_twody = eval_constant_form(s, @SVector [2.0,2.0,0.0])
+@test all(twodx_twody .== ∧(s, VForm(two), EForm(onedx_onedy)))
+@test all(twodx_twody .== (avg_mat * two .* onedx_onedy),)
+
 # 1dx ∧ 1dy = 1 dx∧dy
 onedx = eval_constant_form(s, @SVector [1.0,0.0,0.0])
 onedy = eval_constant_form(s, @SVector [0.0,1.0,0.0])

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -120,16 +120,6 @@ f = VForm([0,1,2,1,0])
                           0.0  1.0 -2.0  1.0;
                           0.0  0.0  1.0 -3.0], atol=1e-3)
 
-# 2 ∧ (1dx) = 2dx
-two = fill(2.0, nv(s))
-onedx = s[:length]
-twodx = 2*s[:length]
-# Test that the averaging matrix can compute a wedge product.
-avg_mat = avg₀₁_mat(s)
-@test all(twodx .== ∧(s, VForm(two), EForm(onedx)))
-@test all(twodx .== (avg_mat * two .* onedx))
-@test all(twodx .== (avg₀₁(s, VForm(two)) .* onedx))
-
 # 2D dual complex
 #################
 
@@ -493,16 +483,6 @@ for k = 0:2
   βᵏ = SimplexForm{k}(collect(1:nsimplices(k,s)))
   @test all(∧(s, α, βᵏ) .≈ βᵏ)
 end
-
-# 2 ∧ (1dx + 1dy) = 2dx + 2dy
-two = fill(2.0, nv(s))
-onedx_onedy = eval_constant_primal_form(s, @SVector [1.0,1.0,0.0])
-twodx_twody = eval_constant_primal_form(s, @SVector [2.0,2.0,0.0])
-# Test that the averaging matrix can compute a wedge product.
-avg_mat = avg₀₁_mat(s)
-@test all(twodx_twody .== ∧(s, VForm(two), EForm(onedx_onedy)))
-@test all(twodx_twody .== (avg_mat * two .* onedx_onedy))
-@test all(twodx_twody .== (avg₀₁(s, VForm(two)) .* onedx_onedy))
 
 # 1dx ∧ 1dy = 1 dx∧dy
 onedx = eval_constant_primal_form(s, @SVector [1.0,0.0,0.0])

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -345,13 +345,8 @@ subdivide_duals!(s, Incenter())
 #plot_pvf(primal_s, ♯(s, E))
 #plot_pvf(primal_s, ♯(s, E, AltPPSharp()))
 
-# Evaluate a constant 1-form α assuming Euclidean space. (Inner product is dot)
-eval_constant_form(s, α::SVector) = map(edges(s)) do e
-  dot(α, point(s, tgt(s,e)) - point(s, src(s,e))) * sign(1,s,e)
-end |> EForm
-
 function test_♯(s, covector::SVector; atol=1e-8)
-  X = eval_constant_form(s, covector)
+  X = eval_constant_primal_form(s, covector)
   # Test that the Hirani field is approximately parallel to the given field.
   X♯ = ♯(s, X)
   @test all(map(X♯) do x
@@ -374,7 +369,7 @@ vfs = [Point3D(1,0,0), Point3D(1,1,0), Point3D(-3,2,0), Point3D(0,0,0),
 primal_s, s = tri_345()
 foreach(vf -> test_♯(s, vf), vfs)
 ♯_m = ♯_mat(s, DesbrunSharp())
-X = eval_constant_form(s, Point3D(1,0,0))
+X = eval_constant_primal_form(s, Point3D(1,0,0))
 X♯ = ♯_m * X
 @test all(X♯ .≈ [Point3D(.8,.4,0), Point3D(0,-1,0), Point3D(-.8,.6,0)])
 
@@ -491,16 +486,17 @@ end
 
 # 2 ∧ (1dx + 1dy) = 2dx + 2dy
 two = fill(2.0, nv(s))
-onedx_onedy = eval_constant_form(s, @SVector [1.0,1.0,0.0])
+onedx_onedy = eval_constant_primal_form(s, @SVector [1.0,1.0,0.0])
+twodx_twody = eval_constant_primal_form(s, @SVector [2.0,2.0,0.0])
 # Test that the averaging matrix can compute a wedge product.
-avg_mat = avg₀₁(s)
-twodx_twody = eval_constant_form(s, @SVector [2.0,2.0,0.0])
+avg_mat = avg₀₁_mat(s)
 @test all(twodx_twody .== ∧(s, VForm(two), EForm(onedx_onedy)))
-@test all(twodx_twody .== (avg_mat * two .* onedx_onedy),)
+@test all(twodx_twody .== (avg_mat * two .* onedx_onedy))
+@test all(twodx_twody .== (avg₀₁(s, VForm(two)) .* onedx_onedy))
 
 # 1dx ∧ 1dy = 1 dx∧dy
-onedx = eval_constant_form(s, @SVector [1.0,0.0,0.0])
-onedy = eval_constant_form(s, @SVector [0.0,1.0,0.0])
+onedx = eval_constant_primal_form(s, @SVector [1.0,0.0,0.0])
+onedy = eval_constant_primal_form(s, @SVector [0.0,1.0,0.0])
 @test ∧(s, onedx, onedy) == map(s[:tri_orientation], s[:area]) do o,a
   # Note by the order of -1 and 1 here that
   a * (o ? -1 : 1)

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -120,6 +120,16 @@ f = VForm([0,1,2,1,0])
                           0.0  1.0 -2.0  1.0;
                           0.0  0.0  1.0 -3.0], atol=1e-3)
 
+# 2 ∧ (1dx) = 2dx
+two = fill(2.0, nv(s))
+onedx = s[:length]
+twodx = 2*s[:length]
+# Test that the averaging matrix can compute a wedge product.
+avg_mat = avg₀₁_mat(s)
+@test all(twodx .== ∧(s, VForm(two), EForm(onedx)))
+@test all(twodx .== (avg_mat * two .* onedx))
+@test all(twodx .== (avg₀₁(s, VForm(two)) .* onedx))
+
 # 2D dual complex
 #################
 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -207,6 +207,28 @@ end
     end
 end
 
+@testset "Averaging Operator" begin
+    for sd in dual_meshes_1D
+        # Test that the averaging matrix can compute a wedge product.
+        V_1 = rand(nv(sd))
+        E_1 = rand(ne(sd))
+        expected_wedge = dec_wedge_product(Tuple{0, 1}, sd)(V_1, E_1)
+        avg_mat = avg₀₁_mat(sd)
+        @test all(expected_wedge .== (avg_mat * V_1 .* E_1))
+        @test all(expected_wedge .== (avg₀₁(sd, VForm(V_1)) .* E_1))
+    end
+
+    for sd in dual_meshes_2D
+        # Test that the averaging matrix can compute a wedge product.
+        V_1 = rand(nv(sd))
+        E_1 = rand(ne(sd))
+        expected_wedge = dec_wedge_product(Tuple{0, 1}, sd)(V_1, E_1)
+        avg_mat = avg₀₁_mat(sd)
+        @test all(expected_wedge .== (avg_mat * V_1 .* E_1))
+        @test all(expected_wedge .== (avg₀₁(sd, VForm(V_1)) .* E_1))
+    end
+end
+
 # TODO: Move all boundary helper functions into CombinatorialSpaces.
 function boundary_inds(::Type{Val{0}}, s)
   ∂1_inds = boundary_inds(Val{1}, s)


### PR DESCRIPTION
This is a small PR for converting 0-forms to 1-forms by taking the mean of the data stored on the faces of an edge.

`avg_01_mat` computes a matrix that performs this averaging operation.
`avg_01` constructs and multiplies the given 0-form by that matrix.
Aliases using unicode subscripts are given.

This functionality is quite old but has never been explicitly upstreamed.