### PR TITLE
3D Mesh IO

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -58,6 +58,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TetGen = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"
 
 [targets]
-test = ["CairoMakie", "CUDA", "Pkg", "Random", "Test", "Statistics"]
+test = ["CairoMakie", "CUDA", "Pkg", "Random", "Test", "Statistics", "TetGen"]

--- a/Project.toml
+++ b/Project.toml
@@ -48,6 +48,7 @@ MeshIO = "0.4"
 Reexport = "0.2, 1.0"
 SparseArrays = "1.9"
 StaticArrays = "0.12, 1.0"
+TetGen = "1.5"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ MeshIO = "7269a6da-0436-5bbc-96c2-40638cbb6118"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-TetGen = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ MeshIO = "7269a6da-0436-5bbc-96c2-40638cbb6118"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+TetGen = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -191,7 +191,7 @@ end
 
 This accessor assumes that the simplicial identities for the dual hold.
 """
-function dual_triangle_vertices(s::HasDeltaSet1D, t...)
+function dual_triangle_vertices(s::HasDeltaSet2D, t...)
   SVector(s[s[t..., :D_∂e1], :D_∂v1],
           s[s[t..., :D_∂e0], :D_∂v1],
           s[s[t..., :D_∂e0], :D_∂v0])
@@ -1025,6 +1025,17 @@ elementary_duals(::Type{Val{2}}, s::AbstractDeltaDualComplex3D, t::Int) =
   incident(s, triangle_center(s,t), :D_∂v1)
 elementary_duals(::Type{Val{3}}, s::AbstractDeltaDualComplex3D, tet::Int) =
   SVector(tetrahedron_center(s,tet))
+
+""" Boundary dual vertices of a dual tetrahedron.
+
+This accessor assumes that the simplicial identities for the dual hold.
+"""
+function dual_tetrahedron_vertices(s::HasDeltaSet3D, t...)
+  SVector(s[s[s[tet, :D_∂t2], :D_∂e2], :D_∂v1],
+          s[s[s[tet, :D_∂t2], :D_∂e2], :D_∂v0],
+          s[s[s[tet, :D_∂t0], :D_∂e0], :D_∂v1],
+          s[s[s[tet, :D_∂t0], :D_∂e0], :D_∂v0])
+end
 
 # 3D oriented dual complex
 #-------------------------

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -23,7 +23,7 @@ export DualSimplex, DualV, DualE, DualTri, DualTet, DualChain, DualForm,
   ⋆, hodge_star, inv_hodge_star, δ, codifferential, ∇², laplace_beltrami, Δ, laplace_de_rham,
   ♭, flat, ♭_mat, ♯, ♯_mat, sharp, ∧, wedge_product, interior_product, interior_product_flat,
   ℒ, lie_derivative, lie_derivative_flat,
-  vertex_center, edge_center, triangle_center, tetrahedron_center, dual_triangle_vertices, dual_edge_vertices,
+  vertex_center, edge_center, triangle_center, tetrahedron_center, dual_tetrahedron_vertices, dual_triangle_vertices, dual_edge_vertices,
   dual_point, dual_volume, subdivide_duals!, DiagonalHodge, GeometricHodge,
   subdivide, PPSharp, AltPPSharp, DesbrunSharp, LLSDDSharp, de_sign,
   ♭♯, ♭♯_mat, flat_sharp, flat_sharp_mat
@@ -1031,10 +1031,10 @@ elementary_duals(::Type{Val{3}}, s::AbstractDeltaDualComplex3D, tet::Int) =
 This accessor assumes that the simplicial identities for the dual hold.
 """
 function dual_tetrahedron_vertices(s::HasDeltaSet3D, t...)
-  SVector(s[s[s[tet, :D_∂t2], :D_∂e2], :D_∂v1],
-          s[s[s[tet, :D_∂t2], :D_∂e2], :D_∂v0],
-          s[s[s[tet, :D_∂t0], :D_∂e0], :D_∂v1],
-          s[s[s[tet, :D_∂t0], :D_∂e0], :D_∂v0])
+  SVector(s[s[s[t..., :D_∂t2], :D_∂e2], :D_∂v1],
+          s[s[s[t..., :D_∂t2], :D_∂e2], :D_∂v0],
+          s[s[s[t..., :D_∂t0], :D_∂e0], :D_∂v1],
+          s[s[s[t..., :D_∂t0], :D_∂e0], :D_∂v0])
 end
 
 # 3D oriented dual complex

--- a/src/MeshInterop.jl
+++ b/src/MeshInterop.jl
@@ -82,7 +82,7 @@ end
 # and the indices of first occurences of the entries in that endofunction.
 # The second return value is equivalent to:
 # `unique(i -> ind_map[i], eachindex[ind_map])`.
-function uniqueperm(coords::AbstractVector{T}, force_unique::Bool) where T
+function unique_index_map(coords::AbstractVector{T}, force_unique::Bool) where T
   uniques = 1:length(coords)
   ind_map = 1:length(coords)
   if force_unique
@@ -115,7 +115,7 @@ is necessary to process `.stl` files which reference points by location.
 """
 function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh; force_unique=false)
   coords = metafree.(coordinates(m))
-  ind_map, uniques = uniqueperm(coords, force_unique)
+  ind_map, uniques = unique_index_map(coords, force_unique)
   tris = faces(m)
   s = EmbeddedDeltaSet2D{Bool, eltype(coords)}()
   add_vertices!(s, length(uniques), point=coords[uniques])
@@ -140,7 +140,7 @@ since some file formats reference points by location.
 """
 function EmbeddedDeltaSet3D(m::GeometryBasics.Mesh; force_unique=false)
   coords = metafree.(coordinates(m))
-  ind_map, uniques = uniqueperm(coords, force_unique)
+  ind_map, uniques = unique_index_map(coords, force_unique)
   tets = faces(m)
   s = EmbeddedDeltaSet3D{Bool, eltype(coords)}()
   add_vertices!(s, length(uniques), point=coords[uniques])

--- a/src/MeshInterop.jl
+++ b/src/MeshInterop.jl
@@ -116,7 +116,7 @@ is necessary to process `.stl` files which reference points by location.
 function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh; force_unique=false)
   coords = metafree.(coordinates(m))
   ind_map, uniques = unique_index_map(coords, force_unique)
-  tris = faces(m)
+  tris = GeometryBasics.faces(m)
   s = EmbeddedDeltaSet2D{Bool, eltype(coords)}()
   add_vertices!(s, length(uniques), point=coords[uniques])
   for tri in tris
@@ -141,7 +141,7 @@ since some file formats reference points by location.
 function EmbeddedDeltaSet3D(m::GeometryBasics.Mesh; force_unique=false)
   coords = metafree.(coordinates(m))
   ind_map, uniques = unique_index_map(coords, force_unique)
-  tets = faces(m)
+  tets = GeometryBasics.faces(m)
   s = EmbeddedDeltaSet3D{Bool, eltype(coords)}()
   add_vertices!(s, length(uniques), point=coords[uniques])
   for tet in tets

--- a/src/MeshInterop.jl
+++ b/src/MeshInterop.jl
@@ -15,44 +15,62 @@ import ..SimplicialSets: EmbeddedDeltaSet2D, EmbeddedDeltaSet3D
 # Export meshes
 ###############
 
-""" Construct a Mesh object from an embedded delta set.
+"""    function GeometryBasics.Mesh(sd::EmbeddedDeltaSet2D)
+
+Construct a Mesh object from an EmbeddedDeltaSet2D.
 """
-function GeometryBasics.Mesh(ds::EmbeddedDeltaSet2D)
-  points = Point{3, Float64}[point(ds)...]
-  tris = TriangleFace{Int}[zip(triangle_vertices(ds)...)...]
+function GeometryBasics.Mesh(sd::EmbeddedDeltaSet2D)
+  points = Point{3, Float64}[point(sd)...]
+  tris = TriangleFace{Int}[zip(triangle_vertices(sd)...)...]
   Mesh(points, tris)
 end
 
-function GeometryBasics.Mesh(ds::EmbeddedDeltaSet3D)
-  points = Point{3, Float64}[point(ds)...]
-  tets = TetrahedronFace{Int}[zip(tetrahedron_vertices(ds)...)...]
+"""    function GeometryBasics.Mesh(ds::EmbeddedDeltaSet3D)
+
+Construct a Mesh object from an EmbeddedDeltaSet3D.
+"""
+function GeometryBasics.Mesh(sd::EmbeddedDeltaSet3D)
+  points = Point{3, Float64}[point(sd)...]
+  tets = TetrahedronFace{Int}[zip(tetrahedron_vertices(sd)...)...]
   Mesh(points, tets)
 end
 
-""" Construct a Mesh object from a dual embedded delta set.
+"""    function GeometryBasics.Mesh(ds::EmbeddedDeltaDualComplex2D{O,R,P};
+                             primal=false) where {O,R,P}
+
+Construct a Mesh object from an EmbeddedDeltaDualComplex2D.
+
+If `primal = true`, then only save primal simplices.
 """
-function GeometryBasics.Mesh(ds::EmbeddedDeltaDualComplex2D{O,R,P};
+function GeometryBasics.Mesh(sd::EmbeddedDeltaDualComplex2D{O,R,P};
                              primal=false) where {O,R,P}
   if primal
-    ds′ = EmbeddedDeltaSet2D{O,P}()
-    copy_parts!(ds′, ds)
-    Mesh(ds′)
+    sd′ = EmbeddedDeltaSet2D{O,P}()
+    copy_parts!(sd′, sd)
+    Mesh(sd′)
   else
-    points = Point{3, Float64}[dual_point(ds)...]
-    tris = TriangleFace{Int}[zip(dual_triangle_vertices(ds)...)...]
+    points = Point{3, Float64}[dual_point(sd)...]
+    tris = TriangleFace{Int}[zip(dual_triangle_vertices(sd)...)...]
     Mesh(points, tris)
   end
 end
 
-function GeometryBasics.Mesh(ds::EmbeddedDeltaDualComplex3D{O,R,P};
+"""    function GeometryBasics.Mesh(ds::EmbeddedDeltaDualComplex3D{O,R,P};
+                             primal=false) where {O,R,P}
+
+Construct a Mesh object from an EmbeddedDeltaDualComplex3D.
+
+If `primal = true`, then only save primal simplices.
+"""
+function GeometryBasics.Mesh(sd::EmbeddedDeltaDualComplex3D{O,R,P};
                              primal=false) where {O,R,P}
   if primal
-    ds′ = EmbeddedDeltaSet3D{O,P}()
-    copy_parts!(ds′, ds)
-    Mesh(ds′)
+    sd′ = EmbeddedDeltaSet3D{O,P}()
+    copy_parts!(sd′, sd)
+    Mesh(sd′)
   else
-    points = Point{3, Float64}[dual_point(ds)...]
-    tets = TetrahedronFace{Int}[zip(dual_tetrahedron_vertices(ds)...)...]
+    points = Point{3, Float64}[dual_point(sd)...]
+    tets = TetrahedronFace{Int}[zip(dual_tetrahedron_vertices(sd)...)...]
     Mesh(points, tets)
   end
 end
@@ -60,26 +78,47 @@ end
 # Import meshes
 ###############
 
-""" Construct EmbeddedDeltaSet2D from Mesh object
+# Given a vector, return an endofunction that picks out the "unique" subset,
+# and the indices of first occurences of the entries in that endofunction.
+# The second return value is equivalent to:
+# `unique(i -> ind_map[i], eachindex[ind_map])`.
+function uniqueperm(coords::AbstractVector{T}, force_unique::Bool) where T
+  uniques = 1:length(coords)
+  ind_map = 1:length(coords)
+  if force_unique
+    s = Dict{T,Int}()
+    i = 1
+    uniques = Vector{Int}()
+    ind_map = map(enumerate(coords)) do (j,c)
+      if c in keys(s)
+        s[c]
+      else
+        s[c] = i
+        push!(uniques, j)
+        i += 1
+        s[c]
+      end
+    end
+  end
+  ind_map, uniques
+end
+
+"""    function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh; force_unique=false)
+
+Construct an EmbeddedDeltaSet2D from a Mesh object
 
 This operator should work for any triangular mesh object. Note that it will
 not preserve any normal, texture, or other attributes from the Mesh object.
 
 The `force_unique` flag merges all points which are at the same location. This
-is necessary to process `.stl` files which references points by location.
+is necessary to process `.stl` files which reference points by location.
 """
 function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh; force_unique=false)
   coords = metafree.(coordinates(m))
-  ind_map = 1:length(coords)
-  if(force_unique) 
-    indices = unique(i->coords[i], 1:length(coords))
-    val2ind = Dict(coords[indices[i]]=>i for i in 1:length(indices))
-    ind_map = map(c->val2ind[c], coords)
-    coords = coords[indices]
-  end
+  ind_map, uniques = uniqueperm(coords, force_unique)
   tris = faces(m)
   s = EmbeddedDeltaSet2D{Bool, eltype(coords)}()
-  add_vertices!(s, length(coords), point=coords)
+  add_vertices!(s, length(uniques), point=coords[uniques])
   for tri in tris
     tri = ind_map[convert.(Int64, tri)]
     glue_sorted_triangle!(s, tri...)
@@ -89,18 +128,22 @@ function EmbeddedDeltaSet2D(m::GeometryBasics.Mesh; force_unique=false)
   s
 end
 
+"""    function EmbeddedDeltaSet3D(m::GeometryBasics.Mesh; force_unique=false)
+
+Construct an EmbeddedDeltaSet3D from a Mesh object
+
+This operator should work for any tetrahedral mesh object. Note that it will
+not preserve any normal, texture, or other attributes from the Mesh object.
+
+The `force_unique` flag merges all points which are at the same location,
+since some file formats reference points by location.
+"""
 function EmbeddedDeltaSet3D(m::GeometryBasics.Mesh; force_unique=false)
   coords = metafree.(coordinates(m))
-  ind_map = 1:length(coords)
-  if(force_unique) 
-    indices = unique(i->coords[i], 1:length(coords))
-    val2ind = Dict(coords[indices[i]]=>i for i in 1:length(indices))
-    ind_map = map(c->val2ind[c], coords)
-    coords = coords[indices]
-  end
+  ind_map, uniques = uniqueperm(coords, force_unique)
   tets = faces(m)
   s = EmbeddedDeltaSet3D{Bool, eltype(coords)}()
-  add_vertices!(s, length(coords), point=coords)
+  add_vertices!(s, length(uniques), point=coords[uniques])
   for tet in tets
     tet = ind_map[convert.(Int64, tet)]
     glue_sorted_tetrahedron!(s, tet...)
@@ -110,7 +153,9 @@ function EmbeddedDeltaSet3D(m::GeometryBasics.Mesh; force_unique=false)
   s
 end
 
-""" Construct EmbeddedDeltaSet2D from mesh file
+"""    function EmbeddedDeltaSet2D(fn::String)
+
+Construct an EmbeddedDeltaSet2D from a mesh file.
 
 This operator should work for any file support for import from MeshIO. Note
 that it will not preserve any normal, texture, or other data beyond points and
@@ -126,14 +171,21 @@ function EmbeddedDeltaSet2D(fn::String)
   end
 end
 
-function EmbeddedDeltaSet3D(fn::String)
-  if(splitext(fn)[2] == ".stl")
-    # The .stl format references points by location so we apply the
-    # force_unique flag
-    EmbeddedDeltaSet3D(FileIO.load(fn); force_unique=true)
-  else
-    EmbeddedDeltaSet3D(FileIO.load(fn))
-  end
-end
+
+#=
+# XXX: No MeshIO file format supports tetrahedra.
+# One thing to do is use TetGen.jl to load .ele files.
+# Or load any mesh as usual, and use TetGen.jl to tesselate it.
+# Note that TetGen.jl has examples of loading several file types and tesselating.
+"""    function EmbeddedDeltaSet3D(fn::String)
+
+Construct an EmbeddedDeltaSet3D from a mesh file.
+
+This operator should work for any file support for import from MeshIO. Note
+that it will not preserve any normal, texture, or other data beyond points and
+tetrahedra from the mesh file.
+"""
+EmbeddedDeltaSet3D(fn::String) = EmbeddedDeltaSet3D(FileIO.load(fn))
+=#
 
 end

--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -356,5 +356,19 @@ function right_scalene_unit_hypot()
   (primal_s, s)
 end
 
+"""    function single_tetrahedron()
+
+Return the primal and dual mesh of a single tetrahedron with points at the origin and Euclidean basis vectors.
+"""
+function single_tetrahedron()
+  pnts = Point3D[
+    (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)]
+  primal_s = EmbeddedDeltaSet3D{Bool, Point3D}()
+  add_vertices!(primal_s, 4, point=pnts)
+  glue_sorted_tetrahedron!(primal_s, 1:4...)
+  s = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(primal_s)
+  subdivide_duals!(s, Barycenter())
+  (primal_s, s)
+end
 
 end

--- a/test/MeshInterop.jl
+++ b/test/MeshInterop.jl
@@ -1,5 +1,6 @@
 module TestMeshInterop
 using CombinatorialSpaces
+using CombinatorialSpaces.Meshes: single_tetrahedron
 using GeometryBasics
 using GeometryBasics: Mesh, QuadFace, volume
 using StaticArrays: SVector
@@ -8,11 +9,9 @@ using TetGen
 
 const Point3D = SVector{3,Float64}
 
-# Import/ Export of meshes
-##########################
-
 # 2D
-#---
+####
+
 s_stl = EmbeddedDeltaSet2D(joinpath(@__DIR__, "assets", "square.stl"))
 @test s_stl isa EmbeddedDeltaSet2D
 @test triangle_vertices(s_stl, 1) == [1,2,3]
@@ -30,44 +29,60 @@ s_msh = EmbeddedDeltaSet2D(msh)
 @test point(s_msh) == point(s)
 @test triangle_vertices(s_msh) == triangle_vertices(s)
 
-# Test consistency with conversion to/from mesh.
-msh = Mesh(s)
-s_msh = EmbeddedDeltaSet2D(msh)
-@test point(s_msh) == point(s)
-@test triangle_vertices(s_msh) == triangle_vertices(s)
+# 3D
+####
 
-# TetGen Compatibility
-######################
+# Construct a single tetrahedron natively.
+s, sd = single_tetrahedron()
+# Construct a single tetrahedron in GeometryBasics.
+function single_tetrahedron_gb()
+  pnts = Point{3}[(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)]
+  Mesh([Tetrahedron(pnts...)])
+end
+msh = single_tetrahedron_gb()
 
-# TetGen.jl/README.md example:
+# Test equivalence of primal mesh & primal components:
+@test Mesh(s) == msh
+@test Mesh(sd, primal=true) == msh
+
+# Test equivalence of dual mesh & dual components:
+sd_to_mesh = Mesh(sd)
+@test length(faces(sd_to_mesh)) == 24
+@test sd_to_mesh.position == sd[:dual_point]
+
+# TetGen compatibility
+#---------------------
+# Create mesh from the TetGen.jl/README.md.
 # https://github.com/JuliaGeometry/TetGen.jl/blob/ea73adce3ea4dfa6062eb84b1eff05f3fcab60a5/README.md
-#--------------------------------------
-#"""
-# Construct a cube out of Quads
-points = Point{3, Float64}[
+function tetgen_readme_mesh()
+  points = Point{3, Float64}[
     (0.0, 0.0, 0.0), (2.0, 0.0, 0.0),
     (2.0, 2.0, 0.0), (0.0, 2.0, 0.0),
     (0.0, 0.0, 12.0), (2.0, 0.0, 12.0),
-    (2.0, 2.0, 12.0), (0.0, 2.0, 12.0)
-]
-
-facets = QuadFace{Cint}[
-    1:4,
-    5:8,
+    (2.0, 2.0, 12.0), (0.0, 2.0, 12.0)]
+  facets = QuadFace{Cint}[
+    1:4, 5:8,
     [1,5,6,2],
     [2,6,7,3],
     [3, 7, 8, 4],
-    [4, 8, 5, 1]
-]
+    [4, 8, 5, 1]]
+  markers = Cint[-1, -2, 0, 0, 0, 0]
+  mesh = Mesh(points, meta(facets, markers=markers))
+  mesh, tetrahedralize(mesh, "Qvpq1.414a0.1");
+end
+msh, tet_msh = tetgen_readme_mesh()
 
-markers = Cint[-1, -2, 0, 0, 0, 0]
-# attach some additional information to our faces!
-mesh = Mesh(points, meta(facets, markers=markers))
-result = tetrahedralize(mesh, "vpq1.414a0.1")
-#"""
-s = EmbeddedDeltaSet3D(result)
+# Import.
+s = EmbeddedDeltaSet3D(tet_msh)
 sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s)
 subdivide_duals!(sd, Circumcenter())
 @test sum(sd[:vol]) ≈ 2*2*12
+s[:edge_orientation] = true
+s[:tri_orientation] = true
+@test is_manifold_like(s)
+
+# Test mesh roundtripping:
+s_to_mesh = Mesh(s)
+@test all(issetequal.(faces(s_to_mesh), faces(tet_msh)))
 
 end

--- a/test/MeshInterop.jl
+++ b/test/MeshInterop.jl
@@ -1,16 +1,18 @@
 module TestMeshInterop
-using Test
-
 using CombinatorialSpaces
-
 using GeometryBasics
+using GeometryBasics: Mesh, QuadFace, volume
 using StaticArrays: SVector
+using Test
+using TetGen
 
 const Point3D = SVector{3,Float64}
 
-# Import meshes
-###############
+# Import/ Export of meshes
+##########################
 
+# 2D
+#---
 s_stl = EmbeddedDeltaSet2D(joinpath(@__DIR__, "assets", "square.stl"))
 @test s_stl isa EmbeddedDeltaSet2D
 @test triangle_vertices(s_stl, 1) == [1,2,3]
@@ -22,13 +24,50 @@ s = EmbeddedDeltaSet2D(joinpath(@__DIR__, "assets", "square.obj"))
 sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3D}(s)
 subdivide_duals!(sd, Barycenter())
 
-# Export meshes
-###############
+# Test consistency with conversion to/from mesh.
+msh = Mesh(s)
+s_msh = EmbeddedDeltaSet2D(msh)
+@test point(s_msh) == point(s)
+@test triangle_vertices(s_msh) == triangle_vertices(s)
 
 # Test consistency with conversion to/from mesh.
 msh = Mesh(s)
 s_msh = EmbeddedDeltaSet2D(msh)
 @test point(s_msh) == point(s)
 @test triangle_vertices(s_msh) == triangle_vertices(s)
+
+# TetGen Compatibility
+######################
+
+# TetGen.jl/README.md example:
+# https://github.com/JuliaGeometry/TetGen.jl/blob/ea73adce3ea4dfa6062eb84b1eff05f3fcab60a5/README.md
+#--------------------------------------
+#"""
+# Construct a cube out of Quads
+points = Point{3, Float64}[
+    (0.0, 0.0, 0.0), (2.0, 0.0, 0.0),
+    (2.0, 2.0, 0.0), (0.0, 2.0, 0.0),
+    (0.0, 0.0, 12.0), (2.0, 0.0, 12.0),
+    (2.0, 2.0, 12.0), (0.0, 2.0, 12.0)
+]
+
+facets = QuadFace{Cint}[
+    1:4,
+    5:8,
+    [1,5,6,2],
+    [2,6,7,3],
+    [3, 7, 8, 4],
+    [4, 8, 5, 1]
+]
+
+markers = Cint[-1, -2, 0, 0, 0, 0]
+# attach some additional information to our faces!
+mesh = Mesh(points, meta(facets, markers=markers))
+result = tetrahedralize(mesh, "vpq1.414a0.1")
+#"""
+s = EmbeddedDeltaSet3D(result)
+sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s)
+subdivide_duals!(sd, Circumcenter())
+@test sum(sd[:vol]) ≈ 2*2*12
 
 end


### PR DESCRIPTION
Close #99 

For the time being, we can use `TetGen` on 3D Mesh objects from `GeometryBasics`.