### PR TITLE
Curry signed integrals into Hodge star

### DIFF
--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -677,7 +677,7 @@ hodge_diag(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, v::Int) =
 hodge_diag(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, e::Int) =
   sum(dual_volume(Val{1}, s, elementary_duals(Val{1},s,e))) / volume(Val{1},s,e)
 hodge_diag(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, t::Int) =
-  1 / volume(Val{2},s,t)
+  1 / volume(Val{2},s,t) * sign(2,s,t)
 
 function ♭(s::AbstractDeltaDualComplex2D, X::AbstractVector, ::DPPFlat)
   # XXX: Creating this lookup table shouldn't be necessary. Of course, we could

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -317,7 +317,7 @@ Returns a cached function that computes the wedge product between a primal
 function dec_wedge_product_pd(::Type{Tuple{1,1}}, sd::HasDeltaSet)
   ♭♯_m = ♭♯_mat(sd)
   Λ_cached = dec_wedge_product(Tuple{1, 1}, sd)
-  (f, g) -> sign(2,sd) .* Λ_cached(f, ♭♯_m * g)
+  (f, g) -> Λ_cached(f, ♭♯_m * g)
 end
 
 """    dec_wedge_product_dp(::Type{Tuple{1,1}}, sd::HasDeltaSet)
@@ -328,7 +328,7 @@ and a primal 1-form.
 function dec_wedge_product_dp(::Type{Tuple{1,1}}, sd::HasDeltaSet)
   ♭♯_m = ♭♯_mat(sd)
   Λ_cached = dec_wedge_product(Tuple{1, 1}, sd)
-  (f, g) -> sign(2,sd) .* Λ_cached(♭♯_m * f, g)
+  (f, g) -> Λ_cached(♭♯_m * f, g)
 end
 
 """    ∧(s::HasDeltaSet, α::SimplexForm{1}, β::DualForm{1})
@@ -515,8 +515,8 @@ function dec_p_hodge_diag(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D{Bool, f
 end
 
 function dec_p_hodge_diag(::Type{Val{2}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
-    tri_areas::Vector{float_type} = sd[:area]
-    return 1 ./ tri_areas
+    signed_tri_areas::Vector{float_type} = sd[:area] .* sign(2,sd)
+    return 1 ./ signed_tri_areas
 end
 
 """

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -995,4 +995,21 @@ end
 """
 Lk = link
 
+function boundary_inds(::Type{Val{0}}, s)
+  ∂1_inds = boundary_inds(Val{1}, s)
+  unique(vcat(s[∂1_inds,:∂v0],s[∂1_inds,:∂v1]))
+end
+
+function boundary_inds(::Type{Val{1}}, s)
+  collect(findall(x -> x != 0, boundary(Val{2},s) * fill(1,ntriangles(s))))
+end
+
+function boundary_inds(::Type{Val{2}}, s)
+  ∂1_inds = boundary_inds(Val{1}, s)
+  inds = map([:∂e0, :∂e1, :∂e2]) do esym
+    vcat(incident(s, ∂1_inds, esym)...)
+  end
+  unique(vcat(inds...))
+end
+
 end

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -6,6 +6,7 @@ using LinearAlgebra
 using Catlab
 using CombinatorialSpaces
 using CombinatorialSpaces.Meshes: tri_345, tri_345_false, grid_345, right_scalene_unit_hypot
+using CombinatorialSpaces.SimplicialSets: boundary_inds
 using CombinatorialSpaces.DiscreteExteriorCalculus: eval_constant_primal_form
 using Random
 using GeometryBasics: Point2, Point3
@@ -227,22 +228,6 @@ end
         @test all(expected_wedge .== (avg_mat * V_1 .* E_1))
         @test all(expected_wedge .== (avg₀₁(sd, VForm(V_1)) .* E_1))
     end
-end
-
-# TODO: Move all boundary helper functions into CombinatorialSpaces.
-function boundary_inds(::Type{Val{0}}, s)
-  ∂1_inds = boundary_inds(Val{1}, s)
-  unique(vcat(s[∂1_inds,:∂v0],s[∂1_inds,:∂v1]))
-end
-function boundary_inds(::Type{Val{1}}, s)
-  collect(findall(x -> x != 0, boundary(Val{2},s) * fill(1,ntriangles(s))))
-end
-function boundary_inds(::Type{Val{2}}, s)
-  ∂1_inds = boundary_inds(Val{1}, s)
-  inds = map([:∂e0, :∂e1, :∂e2]) do esym
-    vcat(incident(s, ∂1_inds, esym)...)
-  end
-  unique(vcat(inds...))
 end
 
 @testset "Primal-Dual Wedge Product 0-1" begin


### PR DESCRIPTION
Converting between primal and dual differential forms requires two pieces of information: the `n`-dimensional volumes of the primal and dual regions of space, and their sign. In the continuous theory, the Hodge star operator accommodates both of these pieces of information. The discrete theory also accounts for this. See for example $$\S 4.1$ from Hirani’s thesis.

Currently, CombinatorialSpaces treats the multiplication by volume-ratios separately from accommodating for the sign. In other words, the Hodge star handles the volume computation, and the `sign` operator is called on-demand.

However, this two-stage process has been a source of confusion. For example, one may expect `dual_derivative(0,sd) * interior_product(sd, u, v)` to compute the exterior derivative of the interior product. But this is not so. Before the changes in this PR, the correct answer was to compute `dual_derivative(0,sd) * (sign(2,sd) .* interior_product(sd, u, v))`, since the Hodge star inside the interior-product computation does not compute the signed volume, which the dual exterior derivative expects. The original 1-1 Lie derivative operation did not account for this.

This has been partially addressed on case-by-case bases. For example, [PR 78](https://github.com/AlgebraicJulia/CombinatorialSpaces.jl/pull/78) explicitly added a sign computation inside the primal-dual 1-1 wedge product.

This PR explicitly captures the sign computation in the Hodge star computation, so discrete operator composition works correctly in all cases.