### PR TITLE
Implement simple linear primal-primal flat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ MeshIO = "7269a6da-0436-5bbc-96c2-40638cbb6118"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"


### PR DESCRIPTION
Currently, we support a flat operation from dual vector-fields to primal one-forms. However, it is sometimes convenient to have a flat operation from primal vector-fields to primal one-forms.

So, this PR adds an implementation of such a flat operation. It is pedagogically simple to understand, and is quick to implement. It assumes that a the values of a primal vector-field can be linearly-interpolated along primal edges. Integrating such a vector-field along one of these primal edges (line-segments) is equivalent to taking the dot-product of the average value of the vector-field with the vector represented by that line segment. This scheme perfectly flattens static vector-fields, of course.

Future PRs can add a cached version of this operation, as in the other "flat matrix" operation, or as a kernel. The interpolation scheme can be improved by doing a modicum of algebra to determine appropriate weights concerning more samples of the vector-field.