### PR TITLE
added basic restrict/mask functions and tests

### DIFF
--- a/src/CombinatorialSpaces.jl
+++ b/src/CombinatorialSpaces.jl
@@ -10,6 +10,7 @@ include("DiscreteExteriorCalculus.jl")
 include("MeshInterop.jl")
 include("FastDEC.jl")
 include("Meshes.jl")
+include("restrictions.jl")
 
 @reexport using .SimplicialSets
 @reexport using .DiscreteExteriorCalculus

--- a/src/restrictions.jl
+++ b/src/restrictions.jl
@@ -1,22 +1,29 @@
+using CombinatorialSpaces, CombinatorialSpaces.SimplicialSets
+
 export restrict, mask!
 
-"""restrict a form to a subset of the points.
+"""    restrict(sd::HasDeltaSet,  
 
-- sd is the mesh,
-- func is a function that chooses the submesh indices corresponding to the boundary
-- form is the vector you want to restrict 
+restrict a form to a subset of the points.
+
+`sd`: the mesh,
+`func`: a function that chooses the submesh indices corresponding to the boundary
+`form`: the vector you want to restrict 
 """
-restrict(sd, func::Function, form) = form[func(sd)]
+restrict(sd::HasDeltaSet, func::Function, form) = form[func(sd)]
 
 restrict(indices, form) = form[indices]
 
-"""mask a form to values on a subset of the points.
+"""    mask(sd::HasDeltaSet, func::Function, form, values)
 
-- sd is the mesh,
-- form is the vector you want to restrict and 
-- values is the vector you want to replace with
-- func is a function that chooses the submesh indices corresponding to the boundary
+Masks a form to values on a subset of the points.
+
+# Arguments:
+`sd`: the mesh
+`func`: function that chooses the submesh indices corresponding to the boundary
+`form`: the vector you want to restrict and 
+`values:` is the vector you want to replace with
 """
-mask!(sd, func::Function, form, values) = setindex!(form, values, func(sd))
+mask!(sd::HasDeltaSet, func::Function, form, values) = setindex!(form, values, func(sd))
 
 mask!(indices, form, values) = setindex!(form, values, indices)

--- a/src/restrictions.jl
+++ b/src/restrictions.jl
@@ -2,7 +2,7 @@ using CombinatorialSpaces, CombinatorialSpaces.SimplicialSets
 
 export restrict, mask!
 
-"""    restrict(sd::HasDeltaSet,  
+"""    restrict(sd::HasDeltaSet, func::Function, form)
 
 restrict a form to a subset of the points.
 

--- a/src/restrictions.jl
+++ b/src/restrictions.jl
@@ -1,0 +1,22 @@
+export restrict, mask!
+
+"""restrict a form to a subset of the points.
+
+- sd is the mesh,
+- func is a function that chooses the submesh indices corresponding to the boundary
+- form is the vector you want to restrict 
+"""
+restrict(sd, func::Function, form) = form[func(sd)]
+
+restrict(indices, form) = form[indices]
+
+"""mask a form to values on a subset of the points.
+
+- sd is the mesh,
+- form is the vector you want to restrict and 
+- values is the vector you want to replace with
+- func is a function that chooses the submesh indices corresponding to the boundary
+"""
+mask!(sd, func::Function, form, values) = setindex!(form, values, func(sd))
+
+mask!(indices, form, values) = setindex!(form, values, indices)

--- a/src/restrictions.jl
+++ b/src/restrictions.jl
@@ -6,6 +6,7 @@ export restrict, mask!
 
 restrict a form to a subset of the points.
 
+# Arguments:
 `sd`: the mesh,
 `func`: a function that chooses the submesh indices corresponding to the boundary
 `form`: the vector you want to restrict 

--- a/test/restrictions.jl
+++ b/test/restrictions.jl
@@ -13,12 +13,14 @@ end
 
 # 0-form
 zero_form = 2*ones(nv(rect));
+idxlen = length(left_wall_idxs(rect))
+max = Float64(length(zero_form) + 1)
 
-@test restrict(left_wall_idxs(rect), zero_form) == fill(2.0, 106)
-@test restrict(rect, left_wall_idxs, zero_form) == fill(2.0, 106)
+@test restrict(left_wall_idxs(rect), zero_form) == fill(2.0, idxlen)
+@test restrict(rect, left_wall_idxs, zero_form) == fill(2.0, idxlen)
 
 copy_zero_form = copy(zero_form);
-mask!(rect, left_wall_idxs, copy_zero_form, fill(1114.0, 106));
+mask!(rect, left_wall_idxs, copy_zero_form, fill(max, idxlen));
 
-@test copy_zero_form[copy_zero_form .== 1114.0] == fill(1114.0, 106)
+@test copy_zero_form[copy_zero_form .== max] == fill(max, idxlen)
 

--- a/test/restrictions.jl
+++ b/test/restrictions.jl
@@ -1,0 +1,24 @@
+using CombinatorialSpaces
+using GeometryBasics: Point3
+Point3D = Point3{Float64}
+
+rect′ = loadmesh(Rectangle_30x10());
+rect = EmbeddedDeltaDualComplex2D{Bool,Float64,Point3D}(rect′);
+subdivide_duals!(rect, Barycenter());
+
+left_wall_idxs(sd) = begin
+    min_y = minimum(p -> p[2], sd[:point])
+    findall(p -> abs(p[2] - min_y) ≤ sd[1,:length]+1e-4, sd[:point])
+end
+
+# 0-form
+zero_form = 2*ones(nv(rect));
+
+@test restrict(left_wall_idxs(rect), zero_form) == fill(2.0, 106)
+@test restrict(rect, left_wall_idxs, zero_form) == fill(2.0, 106)
+
+copy_zero_form = copy(zero_form);
+mask!(rect, left_wall_idxs, copy_zero_form, fill(1114.0, 106));
+
+@test copy_zero_form[copy_zero_form .== 1114.0] == fill(1114.0, 106)
+

--- a/test/restrictions.jl
+++ b/test/restrictions.jl
@@ -7,8 +7,8 @@ rect = EmbeddedDeltaDualComplex2D{Bool,Float64,Point3D}(rect′);
 subdivide_duals!(rect, Barycenter());
 
 left_wall_idxs(sd) = begin
-    min_y = minimum(p -> p[2], sd[:point])
-    findall(p -> abs(p[2] - min_y) ≤ sd[1,:length]+1e-4, sd[:point])
+  min_y = minimum(p -> p[2], sd[:point])
+  findall(p -> abs(p[2] - min_y) ≤ sd[1,:length]+1e-4, sd[:point])
 end
 
 # 0-form

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,4 +25,8 @@ end
   include("Backends.jl")
 end
 
+@testset "Restrictions" begin
+  include("restrictions.jl")
+end
+
 end


### PR DESCRIPTION
This PR upstreams code from [this Decapodes commit](https://github.com/AlgebraicJulia/Decapodes.jl/commit/c78dc466ba0ca3644ffbe6d6f646b6f30ca6f60d) which defines restrict/masking functions for boundary conditions. 

While rudimentary, we'd like to develop this code into more sophisticated code for handling boundary conditions, add it to the `default_dec_generate function`, and possibly integrating it with the sheaf-like semantics in [this Catlab/jpf/sheaves branch](https://github.com/AlgebraicJulia/Catlab.jl/tree/jpf/sheaves).