### PR TITLE
Faster Mesh Binary Subdivision

### DIFF
--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -4,7 +4,7 @@ using GeometryBasics:Point3, Point2
 using Krylov, Catlab, SparseArrays, StaticArrays
 using ..SimplicialSets
 import Catlab: dom,codom
-export multigrid_vcycles, multigrid_wcycles, full_multigrid, repeated_subdivisions, binary_subdivision_map, dom, codom, as_matrix, MultigridData, AbstractGeometricMapSeries, PrimalGeometricMapSeries, finest_mesh, meshes, matrices
+export multigrid_vcycles, multigrid_wcycles, full_multigrid, repeated_subdivisions, binary_subdivision, binary_subdivision_map, dom, codom, as_matrix, MultigridData, AbstractGeometricMapSeries, PrimalGeometricMapSeries, finest_mesh, meshes, matrices
 const Point3D = Point3{Float64}
 const Point2D = Point2{Float64}
 

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -63,7 +63,7 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
   sd[(nv(s)+1:nv(s)+ne(s)), :point] = (s[[:∂v0,:point]] .+ s[[:∂v1,:point]])./2
 
   add_parts!(sd, :E, 2*ne(s)+3*ntriangles(s))
-  # In order of edge index, add from v0 to mid, then v1 to mid
+  # In order of edge index, add from v0 to m, then v1 to m
   for e in edges(s)
     shift_idx = 2*e-1
 
@@ -74,7 +74,7 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
     sd[shift_idx+1, :∂v1] = s[e, :∂v1]
   end
 
-  # In order of triangle index, e0-mid to e1-mid then cycle
+  # In order of triangle index, m0 to m1 then cycle
   for t in triangles(s)
     shift_idx = 3*t-2 + 2*ne(s)
 
@@ -98,7 +98,10 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
     es = triangle_edges(s,t)
     # vs = triangle_vertices(s,t)
 
+    # v2 - m0 - v1, v2 - m1 - v0, v1 - m2 - v0
     split_idx = 2 .* es .- 1
+
+    # m0 - m1, m1 - m2, m0 - m2
     mid_idx = 3*t-2 + 2*ne(s)
 
     # Center triangle
@@ -106,7 +109,7 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
     sd[shift_idx, :∂e1] = mid_idx + 2
     sd[shift_idx, :∂e2] = mid_idx
 
-    # TODO: This needs a check for the split_idx
+    # TODO: This needs a check for the split_idx, where do I add the plus 1?
     # Peripheral triangles
 
     sd[shift_idx+1, :∂e0] = mid_idx + 1

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -63,6 +63,7 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
   sd[(nv(s)+1:nv(s)+ne(s)), :point] = (s[[:∂v0,:point]] .+ s[[:∂v1,:point]])./2
 
   add_parts!(sd, :E, 2*ne(s)+3*ntriangles(s))
+
   # In order of edge index, add from v0 to m, then v1 to m
   for e in edges(s)
     shift_idx = 2*e-1
@@ -96,7 +97,6 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
   for t in triangles(s)
     shift_idx = 4t-3
     es = triangle_edges(s,t)
-    # vs = triangle_vertices(s,t)
 
     # v2 - m0 - v1, v2 - m1 - v0, v1 - m2 - v0
     split_idx = 2 .* es .- 1
@@ -109,9 +109,7 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
     sd[shift_idx, :∂e1] = mid_idx + 2
     sd[shift_idx, :∂e2] = mid_idx
 
-    # TODO: This needs a check for the split_idx, where do I add the plus 1?
     # Peripheral triangles
-
     sd[shift_idx+1, :∂e0] = mid_idx + 1
     sd[shift_idx+1, :∂e1] = split_idx[3]+1
     sd[shift_idx+1, :∂e2] = split_idx[2]+1

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -28,26 +28,26 @@ Subdivide each triangle into 4 via "binary" a.k.a. "medial" subdivision, returni
 
 Binary subdivision results in triangles that resemble the "tri-force" symbol from Legend of Zelda.
 """
-function binary_subdivision(s)
-  is_simplicial_complex(s) || error("Subdivision is supported only for simplicial complexes.")
-  sd = typeof(s)()
-  add_vertices!(sd,nv(s))
-  add_vertices!(sd,ne(s))
-  sd[:point] = [s[:point];
-                (subpart(s,(:∂v0,:point)).+subpart(s,(:∂v1,:point)))/2]
-  succ3(i) = (i+1)%3 == 0 ? 3 : (i+1)%3
-  for t in triangles(s)
-    es = triangle_edges(s,t)
-    glue_sorted_triangle!(sd,(es.+nv(s))...)
-    for i in 1:3
-      glue_sorted_triangle!(sd,
-        triangle_vertices(s,t)[i],
-        triangle_edges(s,t)[succ3(i)]+nv(s),
-        triangle_edges(s,t)[succ3(i+1)]+nv(s))
-    end
-  end
-  sd
-end
+# function binary_subdivision(s)
+#   is_simplicial_complex(s) || error("Subdivision is supported only for simplicial complexes.")
+#   sd = typeof(s)()
+#   add_vertices!(sd,nv(s))
+#   add_vertices!(sd,ne(s))
+#   sd[:point] = [s[:point];
+#                 (subpart(s,(:∂v0,:point)).+subpart(s,(:∂v1,:point)))/2]
+#   succ3(i) = (i+1)%3 == 0 ? 3 : (i+1)%3
+#   for t in triangles(s)
+#     es = triangle_edges(s,t)
+#     glue_sorted_triangle!(sd,(es.+nv(s))...)
+#     for i in 1:3
+#       glue_sorted_triangle!(sd,
+#         triangle_vertices(s,t)[i],
+#         triangle_edges(s,t)[succ3(i)]+nv(s),
+#         triangle_edges(s,t)[succ3(i+1)]+nv(s))
+#     end
+#   end
+#   sd
+# end
 
 # function display_mesh(s)
 #   fig = Figure()
@@ -120,8 +120,8 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
     sd[shift_idx+1, :∂e2] = split_idx[2]+1
 
     sd[shift_idx+2, :∂e0] = mid_idx + 2
-    sd[shift_idx+2, :∂e1] = split_idx[1]+1
-    sd[shift_idx+2, :∂e2] = split_idx[3]
+    sd[shift_idx+2, :∂e1] = split_idx[3]
+    sd[shift_idx+2, :∂e2] = split_idx[1]+1
 
     sd[shift_idx+3, :∂e0] = mid_idx
     sd[shift_idx+3, :∂e1] = split_idx[2]

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -91,6 +91,11 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
     sd[shift_idx+2, :∂v1] = mids[1]
   end
 
+  #       v2
+  #      /  \
+  #    m1 -- m0
+  #   /  \  /  \
+  # v0 -- m2 -- v1
   # Since we add interior mid-to-mid edges by triangle index, we know their exact order
   # Can look at triangle edges to get split edges
   add_parts!(sd, :Tri, 4*ntriangles(s))

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -28,34 +28,6 @@ Subdivide each triangle into 4 via "binary" a.k.a. "medial" subdivision, returni
 
 Binary subdivision results in triangles that resemble the "tri-force" symbol from Legend of Zelda.
 """
-# function binary_subdivision(s)
-#   is_simplicial_complex(s) || error("Subdivision is supported only for simplicial complexes.")
-#   sd = typeof(s)()
-#   add_vertices!(sd,nv(s))
-#   add_vertices!(sd,ne(s))
-#   sd[:point] = [s[:point];
-#                 (subpart(s,(:∂v0,:point)).+subpart(s,(:∂v1,:point)))/2]
-#   succ3(i) = (i+1)%3 == 0 ? 3 : (i+1)%3
-#   for t in triangles(s)
-#     es = triangle_edges(s,t)
-#     glue_sorted_triangle!(sd,(es.+nv(s))...)
-#     for i in 1:3
-#       glue_sorted_triangle!(sd,
-#         triangle_vertices(s,t)[i],
-#         triangle_edges(s,t)[succ3(i)]+nv(s),
-#         triangle_edges(s,t)[succ3(i+1)]+nv(s))
-#     end
-#   end
-#   sd
-# end
-
-# function display_mesh(s)
-#   fig = Figure()
-#   ax = CairoMakie.Axis(fig[1,1], aspect=1)
-#   msh = CairoMakie.wireframe!(ax, s)
-#   fig
-# end
-
 function binary_subdivision(s::EmbeddedDeltaSet2D)
   sd = typeof(s)()
   add_vertices!(sd,nv(s)+ne(s))

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -70,27 +70,18 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
 
     mid = e+nv(s)
 
-    sd[shift_idx, :∂v0] = mid
-    sd[shift_idx, :∂v1] = s[e, :∂v0]
-
-    sd[shift_idx+1, :∂v0] = mid
-    sd[shift_idx+1, :∂v1] = s[e, :∂v1]
+    sd[shift_idx:shift_idx+1, :∂v0] = mid,        mid
+    sd[shift_idx:shift_idx+1, :∂v1] = s[e, :∂v0], s[e, :∂v1]
   end
 
   # In order of triangle index, m0 to m1 then cycle
   for t in triangles(s)
     shift_idx = 3*t-2 + 2*ne(s)
 
-    mids = triangle_edges(s,t) .+ nv(s) # Midpoints
+    m1, m2, m3 = triangle_edges(s,t) .+ nv(s) # Midpoints
 
-    sd[shift_idx, :∂v0] = mids[2]
-    sd[shift_idx, :∂v1] = mids[1]
-
-    sd[shift_idx+1, :∂v0] = mids[3]
-    sd[shift_idx+1, :∂v1] = mids[2]
-
-    sd[shift_idx+2, :∂v0] = mids[3]
-    sd[shift_idx+2, :∂v1] = mids[1]
+    sd[shift_idx:shift_idx+2, :∂v0] = m2, m3, m3
+    sd[shift_idx:shift_idx+2, :∂v1] = m1, m2, m1
   end
 
   #       v2
@@ -105,29 +96,13 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
     shift_idx = 4t-3
     es = triangle_edges(s,t)
 
-    # v2 - m0 - v1, v2 - m1 - v0, v1 - m2 - v0
-    split_idx = 2 .* es .- 1
+    m0_v1, m1_v0, m2_v0 = 2 .* es
+    v2_m0, v2_m1, v1_m2 = 2 .* es .- 1
+    m0_m1, m1_m2, m0_m2 = (3*t-2 + 2*ne(s)) .+ [0,1,2]
 
-    # m0 - m1, m1 - m2, m0 - m2
-    mid_idx = 3*t-2 + 2*ne(s)
-
-    # Center triangle
-    sd[shift_idx, :∂e0] = mid_idx + 1
-    sd[shift_idx, :∂e1] = mid_idx + 2
-    sd[shift_idx, :∂e2] = mid_idx
-
-    # Peripheral triangles
-    sd[shift_idx+1, :∂e0] = mid_idx + 1
-    sd[shift_idx+1, :∂e1] = split_idx[3]+1
-    sd[shift_idx+1, :∂e2] = split_idx[2]+1
-
-    sd[shift_idx+2, :∂e0] = mid_idx + 2
-    sd[shift_idx+2, :∂e1] = split_idx[3]
-    sd[shift_idx+2, :∂e2] = split_idx[1]+1
-
-    sd[shift_idx+3, :∂e0] = mid_idx
-    sd[shift_idx+3, :∂e1] = split_idx[2]
-    sd[shift_idx+3, :∂e2] = split_idx[1]
+    sd[shift_idx:shift_idx+3, :∂e0] = m1_m2, m1_m2, m0_m2, m0_m1
+    sd[shift_idx:shift_idx+3, :∂e1] = m0_m2, m2_v0, v1_m2, v2_m1
+    sd[shift_idx:shift_idx+3, :∂e2] = m0_m1, m1_v0, m0_v1, v2_m0
   end
   sd
 end

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -68,10 +68,12 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
   for e in edges(s)
     shift_idx = 2*e-1
 
-    sd[shift_idx, :∂v0] = e+nv(s)
+    mid = e+nv(s)
+
+    sd[shift_idx, :∂v0] = mid
     sd[shift_idx, :∂v1] = s[e, :∂v0]
 
-    sd[shift_idx+1, :∂v0] = e+nv(s)
+    sd[shift_idx+1, :∂v0] = mid
     sd[shift_idx+1, :∂v1] = s[e, :∂v1]
   end
 

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -62,9 +62,8 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
   sd[1:nv(s), :point] = s[:point]
   sd[(nv(s)+1:nv(s)+ne(s)), :point] = (s[[:∂v0,:point]] .+ s[[:∂v1,:point]])./2
 
+  # v0 -- m -- v1
   add_parts!(sd, :E, 2*ne(s)+3*ntriangles(s))
-
-  # In order of edge index, add from v0 to m, then v1 to m
   for e in edges(s)
     offset = 2*e-1
     mid = e+nv(s)
@@ -78,8 +77,6 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
   #    m1 -- m0
   #   /  \  /  \
   # v0 -- m2 -- v1
-  # Since we add interior mid-to-mid edges by triangle index, we know their exact order
-  # Can look at triangle edges to get split edges
   add_parts!(sd, :Tri, 4*ntriangles(s))
   for t in triangles(s)
     es = triangle_edges(s,t)
@@ -92,11 +89,11 @@ function binary_subdivision(s::EmbeddedDeltaSet2D)
     m0_v1, m1_v0, m2_v0 = 2es
     v2_m0, v2_m1, v1_m2 = 2es .- 1
 
-    # Edge × Vertex
+    # Edge × Vertex:
     sd[[m0_m1, m1_m2, m0_m2], :∂v0] = m1, m2, m2
     sd[[m0_m1, m1_m2, m0_m2], :∂v1] = m0, m1, m0
 
-    # Triangle × Edge
+    # Triangle × Edge:
     offset = 4t-3
     sd[offset:offset+3, :∂e0] = m1_m2, m1_m2, m0_m2, m0_m1
     sd[offset:offset+3, :∂e1] = m0_m2, m2_v0, v1_m2, v2_m1

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -363,19 +363,6 @@ function glue_sorted_triangle!(s::HasDeltaSet2D, v₀::Int, v₁::Int, v₂::Int
   glue_triangle!(s, v₀, v₁, v₂; kw...)
 end
 
-function glue_triangle!(s::HasDeltaSet2D, t::Int, v₀::Int, v₁::Int, v₂::Int; kw...)
-  e1, e2, e3 = get_edge!(s, v₀, v₁), get_edge!(s, v₁, v₂), get_edge!(s, v₀, v₂)
-  s[t, :∂e0] = e2
-  s[t, :∂e1] = e3
-  s[t, :∂e2] = e1
-  t
-end
-
-function glue_sorted_triangle!(s::HasDeltaSet2D, t::Int, v₀::Int, v₁::Int, v₂::Int; kw...)
-  v₀, v₁, v₂ = sort(SVector(v₀, v₁, v₂))
-  glue_triangle!(s, t, v₀, v₁, v₂; kw...)
-end
-
 # 2D oriented simplicial sets
 #----------------------------
 

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -35,7 +35,7 @@ export Simplex, V, E, Tri, Tet, SimplexChain, VChain, EChain, TriChain, TetChain
   tetrahedron_triangles, tetrahedron_edges, tetrahedron_vertices, ntetrahedra,
   tetrahedra, add_tetrahedron!, glue_tetrahedron!, glue_sorted_tetrahedron!,
   glue_sorted_tet_cube!, is_manifold_like, nonboundaries,
-  star, St, closed_star, St̄, link, Lk, simplex_vertices, dimension, 
+  star, St, closed_star, St̄, link, Lk, simplex_vertices, dimension,
   DeltaSet, OrientedDeltaSet, EmbeddedDeltaSet,
   boundary_inds
 
@@ -363,6 +363,19 @@ function glue_sorted_triangle!(s::HasDeltaSet2D, v₀::Int, v₁::Int, v₂::Int
   glue_triangle!(s, v₀, v₁, v₂; kw...)
 end
 
+function glue_triangle!(s::HasDeltaSet2D, t::Int, v₀::Int, v₁::Int, v₂::Int; kw...)
+  e1, e2, e3 = get_edge!(s, v₀, v₁), get_edge!(s, v₁, v₂), get_edge!(s, v₀, v₂)
+  s[t, :∂e0] = e2
+  s[t, :∂e1] = e3
+  s[t, :∂e2] = e1
+  t
+end
+
+function glue_sorted_triangle!(s::HasDeltaSet2D, t::Int, v₀::Int, v₁::Int, v₂::Int; kw...)
+  v₀, v₁, v₂ = sort(SVector(v₀, v₁, v₂))
+  glue_triangle!(s, t, v₀, v₁, v₂; kw...)
+end
+
 # 2D oriented simplicial sets
 #----------------------------
 
@@ -659,7 +672,7 @@ end
 
 """ Wrapper for simplex chain of dimension `n`.
 
-Example: EChain([2,-1,1]) represents the chain 2a-b+c in the 
+Example: EChain([2,-1,1]) represents the chain 2a-b+c in the
 simplicial set with edges a,b,c.
 """
 @vector_struct SimplexChain{n}
@@ -921,8 +934,8 @@ sqdistance(x, y) = sum((x-y).^2)
 
 """ Test whether a given simplicial complex is manifold-like.
 
-According to Hirani, "all simplices of dimension ``k`` with ``0 ≤ k ≤ n - 1`` 
-must be the face of some simplex of dimension ``n`` in the complex." This 
+According to Hirani, "all simplices of dimension ``k`` with ``0 ≤ k ≤ n - 1``
+must be the face of some simplex of dimension ``n`` in the complex." This
 function does not test that simplices do not overlap. Nor does it test that e.g.
 two triangles that share 2 vertices share an edge. Nor does it test that e.g.
 there is at most one triangle that connects 3 vertices. Nor does it test that

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -5,6 +5,7 @@ using Random
 using SparseArrays
 const Point3D = Point3{Float64}
 const Point2D = Point2{Float64}
+import CombinatorialSpaces.Meshes: tri_345
 
 s = triangulated_grid(1,1,1,1,Point3D,false)
 bin_s = binary_subdivision_map(s)
@@ -12,6 +13,22 @@ bin_s = binary_subdivision_map(s)
 for e in 1:ne(s)
   @test findnz(bin_s.matrix[1:nv(s), nv(s)+e]) == ([s[e, :∂v1], s[e, :∂v0]], [0.5, 0.5])
 end
+
+function test_binsubdiv!(t, s)
+  @test nv(t) == nv(s) + ne(s)
+  @test ne(t) == 2*ne(s) + 3*ntriangles(s)
+  @test ntriangles(t) == 4*ntriangles(s)
+  @test orient!(t)
+end
+
+s, = tri_345();
+t = binary_subdivision(s);
+u = binary_subdivision(t);
+v = binary_subdivision(u);
+
+test_binsubdiv!(t, s)
+test_binsubdiv!(u, t)
+test_binsubdiv!(v, u)
 
 s = triangulated_grid(1,1,1/4,sqrt(3)/2*1/4,Point3D,false)
 series = PrimalGeometricMapSeries(s, binary_subdivision_map, 4);

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -6,7 +6,7 @@ using SparseArrays
 const Point3D = Point3{Float64}
 const Point2D = Point2{Float64}
 
-s = triangulated_grid(50,50,1,1,Point3D,false)
+s = triangulated_grid(1,1,1,1,Point3D,false)
 bin_s = binary_subdivision_map(s)
 @test bin_s.matrix[1:nv(s), 1:nv(s)] == I
 for e in 1:ne(s)

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -6,7 +6,7 @@ using SparseArrays
 const Point3D = Point3{Float64}
 const Point2D = Point2{Float64}
 
-s = triangulated_grid(1,1,1,1,Point3D,false)
+s = triangulated_grid(50,50,1,1,Point3D,false)
 bin_s = binary_subdivision_map(s)
 @test bin_s.matrix[1:nv(s), 1:nv(s)] == I
 for e in 1:ne(s)


### PR DESCRIPTION
This PR builds upon PR #137 by also targeting `binary_subdivision` for optimization. By making full use of the simplicial invariants in CombinatorialSpaces, the function is able to directly create the required vertices, edges and triangles instead of relying on the slower `glue_sorted_triangle!` function.

Speedups upon PR creation are already at x2 and I expect better manipulation of ACSet setting can drive further speedups.