### PR TITLE
3D Advection and DD-01 PD-21 Wedge products

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ authors = ["Luke Morris <luke.morris@ufl.edu>", "George Rauta <grauta@ufl.edu>",
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 GATlab = "f0ffcf3b-d13a-433e-917c-cc44ccf5ead2"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ authors = ["Luke Morris <luke.morris@ufl.edu>", "George Rauta <grauta@ufl.edu>",
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 GATlab = "f0ffcf3b-d13a-433e-917c-cc44ccf5ead2"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"

--- a/Project.toml
+++ b/Project.toml
@@ -44,6 +44,7 @@ Artifacts = "1.9, 1"
 CUDA = "5.2"
 Catlab = "0.17"
 DelaunayTriangulation = "1.6.4"
+Distributions = "0.25.124"
 FileIO = "^1"
 GATlab = "0.1.5, 0.2"
 GeometryBasics = "0.5"
@@ -69,6 +70,7 @@ julia = "1.10"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DelaunayTriangulation = "927a84f5-c5f4-47a5-9785-b46e178433df"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -76,4 +78,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CairoMakie", "CUDA", "DelaunayTriangulation", "Meshes", "Pkg", "Random", "Test", "Statistics"]
+test = ["CairoMakie", "CUDA", "DelaunayTriangulation", "Distributions", "Meshes", "Pkg", "Random", "Test", "Statistics"]

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -29,7 +29,8 @@ export DualSimplex, DualV, DualE, DualTri, DualTet, DualChain, DualForm,
   subdivide, PDSharp, PPSharp, AltPPSharp, DesbrunSharp, LLSDDSharp, de_sign,
   DPPFlat, PPFlat,
   ♭♯, ♭♯_mat, flat_sharp, flat_sharp_mat, dualize,
-  p2_d2_interpolation, p3_d3_interpolation, eval_constant_primal_form, eval_constant_dual_form
+  p2_d2_interpolation, p3_d3_interpolation, eval_constant_primal_form, eval_constant_dual_form,
+  as_vec
 
 import Base: ndims
 import Base: *
@@ -632,6 +633,8 @@ hodge_diag(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, e::Int) =
 hodge_diag(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, t::Int) =
   1 / volume(Val{2},s,t)
 
+as_vec(s,e) = (point(s, tgt(s,e)) - point(s, src(s,e))) * sign(1,s,e)
+
 function ♭(s::AbstractDeltaDualComplex2D, X::AbstractVector, ::DPPFlat)
   # XXX: Creating this lookup table shouldn't be necessary. Of course, we could
   # index `tri_center` but that shouldn't be necessary either. Rather, we should
@@ -643,7 +646,7 @@ function ♭(s::AbstractDeltaDualComplex2D, X::AbstractVector, ::DPPFlat)
   # For each primal edge:
   map(edges(s)) do e
     # Get the vector from src to tgt (oriented correctly).
-    e_vec = (point(s, tgt(s,e)) - point(s, src(s,e))) * sign(1,s,e)
+    e_vec = as_vec(s,e)
     # Grab all the dual edges of this primal edge.
     dual_edges = elementary_duals(1,s,e)
     # And the corresponding lengths.
@@ -667,7 +670,7 @@ function ♭_mat(s::AbstractDeltaDualComplex2D, p2s, ::DPPFlat)
   ♭_mat = spzeros(mat_type, ne(s), ntriangles(s))
   for e in edges(s)
     # The vector associated with this primal edge.
-    e_vec = (point(s, tgt(s,e)) - point(s, src(s,e))) * sign(1,s,e)
+    e_vec = as_vec(s,e)
     # The triangles associated with this primal edge.
     tris = p2s[e,:].nzind
     # The dual vertex at the center of this primal edge.
@@ -695,7 +698,7 @@ function ♭(s::AbstractDeltaDualComplex2D, X::AbstractVector, ::PPFlat)
   map(edges(s)) do e
     vs = edge_vertices(s,e)
     l_vec = mean(X[vs])
-    e_vec = (point(s, tgt(s,e)) - point(s, src(s,e))) * sign(1,s,e)
+    e_vec = as_vec(s,e)
     dot(l_vec, e_vec)
   end
 end
@@ -704,7 +707,7 @@ function ♭_mat(s::AbstractDeltaDualComplex2D, ::PPFlat)
   mat_type = SMatrix{1, length(eltype(s[:point])), eltype(eltype(s[:point])), length(eltype(s[:point]))}
   ♭_mat = spzeros(mat_type, ne(s), nv(s))
   for e in edges(s)
-    e_vec = (point(s, tgt(s,e)) - point(s, src(s,e))) * sign(1,s,e)
+    e_vec = as_vec(s,e)
     vs = edge_vertices(s,e)
     ♭_mat[e, vs[1]] = 0.5 * mat_type(e_vec)
     ♭_mat[e, vs[2]] = 0.5 * mat_type(e_vec)

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -435,17 +435,15 @@ weddge (without explicitly dividing by 2.)
 # Given (volumetric) data assigned to the faces of a tetrahedron,
 # take a weighted combination according to the usual Whitney scheme.
 function whitney_mat(::Type{Tuple{2}}, sd::AbstractDeltaDualComplex3D)
-  m = spzeros(ntetrahedra(sd), ntriangles(sd))
-  for tet in tetrahedra(sd)
+  I_vec = repeat(tetrahedra(sd), inner=4)
+  J_vec = map(x -> tetrahedron_triangles(sd, x), tetrahedra(sd))
+  V_vec = map(tetrahedra(sd)) do tet
+    # The scheme in make_dual_simplices_3d! explains the reshape.
     subs = subsimplices(3, sd, tet)
-    d_tets = map(x -> subs[x], [1:6, 7:12, 13:18, 19:24]) # See make_dual_simplices_3d!.
-    ws = map(x -> sum(sd[x, :dual_vol]), d_tets)
-    normalize!(ws,1)
-    foreach(ws, tetrahedron_triangles(sd, tet)) do w,tri
-      m[tet,tri] = w
-    end
+    d_vols = sum(eachrow(reshape(sd[subs, :dual_vol], (6,4))))
+    normalize!(d_vols, 1)
   end
-  m
+  sparse(I_vec, reduce(vcat, J_vec), reduce(vcat, V_vec))
 end
 
 function dec_wedge_product_pd(::Type{Tuple{2,1}}, sd::HasDeltaSet3D)

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -288,7 +288,7 @@ end
 
 # Return a matrix that can be multiplied to a dual 0-form, before being
 # elementwise-multiplied by a dual 1-form, encoding the wedge product.
-function wedge_dd_01_mat(sd::HasDeltaSet)
+function wedge_dd_01_mat(sd::HasDeltaSet2D)
   m = spzeros(ne(sd), ntriangles(sd))
   for e in edges(sd)
     des = elementary_duals(1,sd,e)
@@ -297,6 +297,24 @@ function wedge_dd_01_mat(sd::HasDeltaSet)
     ws = sd[des, :dual_length] ./ sum(sd[des, :dual_length])
     for (w,t) in zip(ws,tris)
       m[e,t] = w
+    end
+  end
+  m
+end
+
+# TODO: Instead of copying-and-pasting,
+# use higher-level helper functions/ arithmetic with degree of complex.
+# Return a matrix that can be multiplied to a dual 0-form, before being
+# elementwise-multiplied by a dual 1-form, encoding the wedge product.
+function wedge_dd_01_mat(sd::HasDeltaSet3D)
+  m = spzeros(ntriangles(sd), ntetrahedra(sd))
+  for tri in triangles(sd)
+    des = elementary_duals(2,sd,tri)
+    dvs = sd[des, :D_∂v0]
+    tets = only.(incident(sd, dvs, :tet_center))
+    ws = sd[des, :dual_length] ./ sum(sd[des, :dual_length])
+    for (w,tet) in zip(ws,tets)
+      m[tri,tet] = w
     end
   end
   m

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -448,12 +448,14 @@ end
 
 function dec_wedge_product_pd(::Type{Tuple{2,1}}, sd::HasDeltaSet3D)
   wm = whitney_mat(Tuple{2}, sd)
-  (f, g) -> wm * (f .* g)
+  sgns = sign(3, sd)
+  (f, g) -> sgns .* (wm * (f .* g))
 end
 
 function dec_wedge_product_dp(::Type{Tuple{1,2}}, sd::HasDeltaSet3D)
   wm = whitney_mat(Tuple{2}, sd)
-  (f, g) -> wm * (f .* g)
+  sgns = sign(3, sd)
+  (f, g) -> sgns .* (wm * (f .* g))
 end
 
 # Boundary and Co-boundary

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -17,7 +17,7 @@ using ..Multigrid: AbstractGeometricMapSeries, AbstractSubdivisionScheme, Binary
 using ACSets
 using Base.Iterators
 using KernelAbstractions
-using LinearAlgebra: cross, dot, Diagonal, factorize, norm
+using LinearAlgebra: cross, dot, Diagonal, factorize, norm, normalize!
 using SparseArrays: sparse, spzeros, SparseMatrixCSC
 using StaticArrays: SVector, MVector
 using Krylov: cg
@@ -30,7 +30,7 @@ export dec_wedge_product, cache_wedge, dec_c_wedge_product, dec_c_wedge_product!
   dec_hodge_star, dec_inv_hodge_star,
   dec_wedge_product_pd, dec_wedge_product_dp, ∧,
   interior_product_dd, ℒ_dd,
-  dec_wedge_product_dd,
+  dec_wedge_product_dd, whitney_mat,
   Δᵈ, dec_Δ⁻¹,
   avg₀₁, avg_01, avg₀₁_mat, avg_01_mat,
   d0_p0_interpolation, p0_d0_interpolation
@@ -429,6 +429,34 @@ weddge (without explicitly dividing by 2.)
 ∧(s::HasDeltaSet, α::DualForm{1}, β::SimplexForm{1}) =
   dec_wedge_product_dp(Tuple{1,1}, s)(α, β)
 
+# TODO: This could more strongly rely on simplicial identities, instead of relying
+# on the order of subsimplices from make_dual_simplices_3d!.
+
+# Given (volumetric) data assigned to the faces of a tetrahedron,
+# take a weighted combination according to the usual Whitney scheme.
+function whitney_mat(::Type{Tuple{2}}, sd::AbstractDeltaDualComplex3D)
+  m = spzeros(ntetrahedra(sd), ntriangles(sd))
+  for tet in tetrahedra(sd)
+    subs = subsimplices(3, sd, tet)
+    d_tets = map(x -> subs[x], [1:6, 7:12, 13:18, 19:24]) # See make_dual_simplices_3d!.
+    ws = map(x -> sum(sd[x, :dual_vol]), d_tets)
+    normalize!(ws,1)
+    foreach(ws, tetrahedron_triangles(sd, tet)) do w,tri
+      m[tet,tri] = w
+    end
+  end
+  m
+end
+
+function dec_wedge_product_pd(::Type{Tuple{2,1}}, sd::HasDeltaSet3D)
+  wm = whitney_mat(Tuple{2}, sd)
+  (f, g) -> wm * (f .* g)
+end
+
+function dec_wedge_product_dp(::Type{Tuple{1,2}}, sd::HasDeltaSet3D)
+  wm = whitney_mat(Tuple{2}, sd)
+  (f, g) -> wm * (f .* g)
+end
 
 # Boundary and Co-boundary
 #-------------------------

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -1078,6 +1078,10 @@ function boundary_inds(::Type{Val{2}}, s::HasDeltaSet2D)
   unique(vcat(inds...))
 end
 
+function boundary_inds(::Type{Val{2}}, s::HasDeltaSet3D)
+  findall(x -> x < 2, counts(vcat(s[:∂t0], s[:∂t1], s[:∂t2], s[:∂t3])))
+end
+
 function interior(::Type{Val{0}}, s::HasDeltaSet2D)
   boundaries = boundary_inds(Val{0}, s)
   setdiff(vertices(s), boundaries)

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -583,7 +583,7 @@ nrml = MvNormal(μ, I(3))
 # Taking the inverse hodge star would multiply by the sign of the tetrahedron, and multiply by the volume,
 # which would give a Primal 3-form of the mass stored in each tetrahedron.
 C = map(sign(3,sd), sd[sd[:tet_center], :dual_point]) do sgn,p
-  norm(p - μ) ≤ 3.0 ? sgn * 15.8 * pdf(nrml,p) : 0.0
+  norm(p - μ) ≤ 3.0 ? sgn * 15.8e2 * pdf(nrml,p) : 0.0
 end
 
 # This is a dual 1-form, which encodes a constant gradient pointing "up".
@@ -600,13 +600,16 @@ function midpoint_method_advection!(C, dZ, k, dual_div, wdd)
   dC = zeros(length(C))
   for _ in 1:1e5
     advection_3D_timestep!(dC, C, dZ, k, dual_div, wdd)
+    dC[b_tets] .= 0.0
     advection_3D_timestep!(dtC, C .+ (dt/2 * dC), dZ, k, dual_div, wdd)
     C .+= dt * dtC
+    C[b_tets] .= 0.0
   end
   C
 end
 
 k = 1
+C[b_tets] .= 0.0
 C_adv = midpoint_method_advection!(copy(C), dZ, k, dual_div, wdd)
 
 # In 1 second, the center of mass move should move by approximately k.
@@ -622,6 +625,9 @@ displacement(C,C_adv)
 abs_error(C,C_adv,k)
 rel_error(C,C_adv,k)
 
+b_tets = boundary_inds(Val{3}, sd)
+
+s2sd = sign(2,sd)
 # TODO: Upstream the rest of this Lie derivative.
 # -1^(k(n-k)) star(star(a) wedge X)
 # where a = d(C) = Dual 1-Form, n=3, and k=1.
@@ -635,13 +641,16 @@ function midpoint_method_lie!(C, dZ, k, s3, wpd, is2, dd0)
   dtC = zeros(length(C))
   dC = zeros(length(C))
   for _ in 1:1e5
-    lie_3D_timestep!(dtC, C, dZ, k, s3, wpd, is2, dd0)
+    lie_3D_timestep!(dC, C, dZ, k, s3, wpd, is2, dd0)
+    dC[b_tets] .= 0.0
     lie_3D_timestep!(dtC, C .+ (dt/2 * dC), dZ, k, s3, wpd, is2, dd0)
     C .+= dt * dtC
+    C[b_tets] .= 0.0
   end
   C
 end
 
+C[b_tets] .= 0.0
 k = 1e-3
 C_lie = midpoint_method_lie!(copy(C), dZ, k, s3, wpd, is2, dd0)
 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -575,6 +575,105 @@ is3 = inv_hodge_star(Val{3}, sd, DiagonalHodge()) # From Dual 0-forms to Primal 
 
 dual_div = s3 * d2 * is2
 
+# Also set up a single-tetrahedron mesh for simple unit tests.
+_, sd1 = single_tetrahedron()
+
+@testset "3D DD 0-1 Wedge Product" begin
+  # Test on the full tetgen mesh.
+  wdd_mat = CombinatorialSpaces.FastDEC.wedge_dd_01_mat(sd)
+
+  # Dimensions: ntriangles × ntetrahedra.
+  @test size(wdd_mat) == (ntriangles(sd), ntetrahedra(sd))
+
+  # Each row (primal triangle) has weights that sum to 1,
+  # since dual lengths are normalized per triangle.
+  row_sums = vec(sum(wdd_mat, dims=2))
+  @test all(isapprox.(row_sums, 1.0, atol=1e-14))
+
+  # All weights are non-negative (they are ratios of dual lengths).
+  @test all(wdd_mat .≥ 0)
+
+  # Wedging a constant dual 0-form with any dual 1-form just scales:
+  # (m * c*ones) .* g = c * (m * ones) .* g = c * g.
+  c = 3.0
+  const_f = fill(c, ntetrahedra(sd))
+  g = randn(ntriangles(sd))
+  @test wdd(const_f, g) ≈ c .* g
+
+  # Commutativity: Λ₀₁(f,g) = Λ₁₀(g,f).
+  wdd10 = dec_wedge_product_dd(Val(1), Val(0), sd)
+  f = randn(ntetrahedra(sd))
+  @test wdd(f, g) ≈ wdd10(g, f)
+
+  # Same tests on single-tetrahedron mesh.
+  wdd1_mat = CombinatorialSpaces.FastDEC.wedge_dd_01_mat(sd1)
+  @test size(wdd1_mat) == (ntriangles(sd1), ntetrahedra(sd1))
+  @test all(isapprox.(vec(sum(wdd1_mat, dims=2)), 1.0, atol=1e-14))
+  @test all(wdd1_mat .≥ 0)
+end
+
+@testset "3D Whitney Matrix" begin
+  wm = whitney_mat(Val(2), sd)
+
+  # Dimensions: ntetrahedra × ntriangles.
+  @test size(wm) == (ntetrahedra(sd), ntriangles(sd))
+
+  # Each row (tet) sums to 1 (normalized L1 weights).
+  row_sums = vec(sum(wm, dims=2))
+  @test all(isapprox.(row_sums, 1.0, atol=1e-14))
+
+  # All weights are non-negative (dual volumes are positive).
+  @test all(wm .≥ 0)
+
+  # Each tet has exactly 4 non-zero entries (its 4 face triangles).
+  nnz_per_row = [length(wm[i,:].nzind) for i in 1:ntetrahedra(sd)]
+  @test all(nnz_per_row .== 4)
+
+  # Same on single-tetrahedron mesh.
+  wm1 = whitney_mat(Val(2), sd1)
+  @test size(wm1) == (ntetrahedra(sd1), ntriangles(sd1))
+  @test all(isapprox.(vec(sum(wm1, dims=2)), 1.0, atol=1e-14))
+  @test all(wm1 .≥ 0)
+end
+
+@testset "3D PD 2-1 Wedge Product" begin
+  # Dimensions check.
+  f_rand = randn(ntriangles(sd))
+  g_rand = randn(ntriangles(sd))
+  result = wpd(f_rand, g_rand)
+  @test length(result) == ntetrahedra(sd)
+
+  # DP wedge should also produce the right dimensions.
+  wdp = dec_wedge_product_dp(Val(1), Val(2), sd)
+  result_dp = wdp(g_rand, f_rand)
+  @test length(result_dp) == ntetrahedra(sd)
+
+  # PD(f,g) = DP(g,f) by definition (both use same Whitney matrix and signs).
+  @test wpd(f_rand, g_rand) ≈ wdp(g_rand, f_rand)
+end
+
+@testset "3D boundary_inds(Val(2))" begin
+  # On the single tetrahedron, all 4 triangles are boundary faces.
+  b2_single = boundary_inds(Val(2), sd1)
+  @test length(b2_single) == ntriangles(sd1)
+  @test sort(b2_single) == sort(triangles(sd1))
+
+  # On the full mesh, boundary triangles are a strict subset of all triangles.
+  b2 = boundary_inds(Val(2), sd)
+  @test !isempty(b2)
+  @test length(b2) < ntriangles(sd)
+
+  # Every boundary triangle should appear in exactly one tetrahedron's face list.
+  for tri in b2
+    incident_tets = union(
+      incident(sd, tri, :∂t0)...,
+      incident(sd, tri, :∂t1)...,
+      incident(sd, tri, :∂t2)...,
+      incident(sd, tri, :∂t3)...)
+    @test length(incident_tets) == 1
+  end
+end
+
 μ = Point3D(1,1,6)
 nrml = MvNormal(μ, I(3))
 # This is a dual 0-form (mass density [M L^⁻³]).
@@ -689,6 +788,18 @@ rel_error(C,D,k) = abs_error(C,D,k) / norm(k)
 
 @test rel_error(C, C_adv, 1) < 0.5
 
+# The displacement should be primarily in the +z direction.
+disp_adv = displacement(C, C_adv)
+@test disp_adv[3] > 0  # Moving in +z direction
+@test abs(disp_adv[3]) > abs(disp_adv[1])  # z-component dominates x
+@test abs(disp_adv[3]) > abs(disp_adv[2])  # z-component dominates y
+
+# Mass should be approximately conserved (density doesn't vanish or blow up).
+total_mass_before = sum(is3 * C)
+total_mass_after = sum(is3 * C_adv)
+@test total_mass_after > 0
+@test abs(total_mass_after - total_mass_before) / abs(total_mass_before) < 0.5
+
 # Lie derivative on a dual 0-form: L_v C = ∇·(Cv) - C(∇·v)
 # i.e. ∂_t C = -L_v C = -∇·(Cv) + C(∇·v)
 # The first term is the advection (divergence form), and the second is a correction.
@@ -716,6 +827,12 @@ k = 1
 C_lie = midpoint_method_lie!(copy(C), dZ, k, dual_div, wdd, div_v)
 
 @test rel_error(C, C_lie, k) < 0.5
+
+# The Lie derivative displacement should also be primarily in +z.
+disp_lie = displacement(C, C_lie)
+@test disp_lie[3] > 0
+@test abs(disp_lie[3]) > abs(disp_lie[1])
+@test abs(disp_lie[3]) > abs(disp_lie[2])
 
 end
 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -602,6 +602,11 @@ end
 @test all(abs.(dd1*dZ) .< 1e-14)
 # Test that dXdY is closed.
 @test all(abs.(d2*dXdY) .< 1e-15)
+
+# Test the PD 2-1 wedge product: dXdY ∧ dZ should approximate tet volumes
+# (since dXdY encodes unit z-areas and dZ encodes unit z-gradient).
+wpd_result = wpd(dXdY, dZ)
+@test length(wpd_result) == ntetrahedra(sd)
 #=
 julia> histogram((is2*dZ - dXdY), nbins=20)
                   ┌                                        ┐ 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -672,7 +672,6 @@ function midpoint_method_advection!(C, dZ, k, dual_div, wdd)
   C
 end
 
-b_tris = boundary_inds(Val{2}, sd)
 b_tets = boundary_inds(Val{3}, sd)
 
 k = 1

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -570,36 +570,29 @@ wdd = dec_wedge_product_dd(Tuple{0,1}, sd)
 is2 = inv_hodge_star(Val{2}, sd, DiagonalHodge()) # From Dual 1-forms to Primal 2-forms.
 d2 = d(2,sd)
 wpd = dec_wedge_product_pd(Tuple{2,1}, sd)
-s2 = ⋆(Val{2}, sd, DiagonalHodge())
-is2 = inv_hodge_star(Val{2}, sd, DiagonalHodge()) # From Dual 1-forms to Primal 2-forms.
 s3 = ⋆(Val{3}, sd, DiagonalHodge())
-# TODO: Upstream sign currying.
-s3.diag .*= sign(3,sd)
 is3 = inv_hodge_star(Val{3}, sd, DiagonalHodge()) # From Dual 0-forms to Primal 3-forms.
-is3.diag .*= sign(3,sd)
 
 dual_div = s3 * d2 * is2
 
 μ = Point3D(1,1,6)
 nrml = MvNormal(μ, I(3))
-# This is a dual 0-form. It has units of (signed) mass density [M L^⁻³].
-# Taking the inverse hodge star would multiply by the sign of the tetrahedron, and multiply by the volume,
-# which would give a Primal 3-form of the mass stored in each tetrahedron.
-C = map(sign(3,sd), sd[sd[:tet_center], :dual_point]) do sgn,p
-  norm(p - μ) ≤ 3.0 ? sgn * 15.8e2 * pdf(nrml,p) : 0.0
+# This is a dual 0-form (mass density [M L^⁻³]).
+C = map(sd[sd[:tet_center], :dual_point]) do p
+  norm(p - μ) ≤ 3.0 ? 15.8e2 * pdf(nrml,p) : 0.0
 end
 
 # This is a dual 1-form, which encodes a constant gradient pointing "up".
-dZ = dd0 * (sign(3,sd) .* map(x -> x[3], sd[sd[:tet_center], :dual_point]))
+dZ = dd0 * map(x -> x[3], sd[sd[:tet_center], :dual_point])
 
 # This is a primal 2-form, encoding (signed) unit areas parallel to the z=0 plane.
 dXdY = map(triangles(sd)) do tri
-  e1, e2, _ = triangle_edges(sd,tri)
-  e1_vec, e2_vec = as_vec(sd,e1), as_vec(sd,e2)
-  (cross(e1_vec, e2_vec) * sign(2,sd,tri))[3] / 2
+  _, e2, e3 = triangle_edges(sd,tri)
+  e3_vec, e2_vec = as_vec(sd,e3), as_vec(sd,e2)
+  (cross(e3_vec, e2_vec) * sign(2,sd,tri))[3] / 2
   # Note that normalizing is the same as dividing by 2*sd[tri, :area],
   # so the above is equivalent to:
-  #n = normalize(cross(e1_vec, e2_vec) * sign(2,sd,tri))
+  #n = normalize(cross(e3_vec, e2_vec) * sign(2,sd,tri))
   #sd[tri, :area] * n[3] # i.e. n ⋅ SVector{3,Float64}(0,0,1)
 end
 
@@ -657,7 +650,7 @@ julia> histogram((is2*dZ - dXdY).^2, nbins=20)
 
 # Demonstrate advection in 3D using the midpoint method.
 function advection_3D_timestep!(dtC, C, dZ, k, dual_div, wdd)
-  dtC .= dual_div * (k * wdd(C, dZ))
+  dtC .= -dual_div * (k * wdd(C, dZ))
 end
 
 function midpoint_method_advection!(C, dZ, k, dual_div, wdd)
@@ -674,11 +667,14 @@ function midpoint_method_advection!(C, dZ, k, dual_div, wdd)
   C
 end
 
+b_tris = boundary_inds(Val{2}, sd)
+b_tets = boundary_inds(Val{3}, sd)
+
 k = 1
 C[b_tets] .= 0.0
 C_adv = midpoint_method_advection!(copy(C), dZ, k, dual_div, wdd)
 
-# In 1 second, the center of mass move should move by approximately k.
+# In 1 second, the center of mass should move by approximately k in the +z direction.
 function center_of_mass(D)
   mass = is3 * D
   sum(mass .* (sd[sd[:tet_center], :dual_point])) / sum(mass)
@@ -687,20 +683,12 @@ displacement(C,D) = center_of_mass(D) - center_of_mass(C)
 abs_error(C,D,k) = norm(displacement(C,D) - SVector{3,Float64}(0,0,k))
 rel_error(C,D,k) = abs_error(C,D,k) / norm(k)
 
-displacement(C,C_adv)
-abs_error(C,C_adv,k)
-rel_error(C,C_adv,k)
+@test rel_error(C, C_adv, 1) < 0.5
 
-b_tris = boundary_inds(Val{2}, sd)
-b_tets = boundary_inds(Val{3}, sd)
-
-s2sd = sign(2,sd)
-# TODO: Upstream the rest of this Lie derivative.
-# -1^(k(n-k)) star(star(a) wedge X)
-# where a = d(C) = Dual 1-Form, n=3, and k=1.
-# s3(is2(a) wedge_primal2_dual1 X)
+# Lie derivative formulation: ∂_t C = -L_v C = -i_v(dC) = -(-1)^(k(n-k)) ⋆(⋆(dC) ∧ v♭)
+# For k=1, n=3: (-1)^(1*2) = 1, so ∂_t C = -⋆(⋆(dC) ∧ v♭) = -s3(is2(dC) ∧ dZ)
 function lie_3D_timestep!(dtC, C, dZ, k, s3, wpd, is2, dd0)
-  dtC .= k * s3 * wpd(is2 * dd0 * C, dZ)
+  dtC .= -k * s3 * wpd(is2 * dd0 * C, dZ)
 end
 
 function midpoint_method_lie!(C, dZ, k, s3, wpd, is2, dd0)
@@ -721,9 +709,7 @@ C[b_tets] .= 0.0
 k = 1e-3
 C_lie = midpoint_method_lie!(copy(C), dZ, k, s3, wpd, is2, dd0)
 
-displacement(C,C_lie)
-abs_error(C,C_lie,k)
-rel_error(C,C_lie,k)
+@test rel_error(C, C_lie, k) < 0.5
 
 end
 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -567,11 +567,11 @@ subdivide_duals!(sd, Barycenter());
 dd0 = dual_derivative(0,sd)
 dd1 = dual_derivative(1,sd)
 wdd = dec_wedge_product_dd(Val(0), Val(1), sd)
-is2 = inv_hodge_star(Val{2}, sd, DiagonalHodge()) # From Dual 1-forms to Primal 2-forms.
+is2 = inv_hodge_star(Val(2), sd, DiagonalHodge()) # From Dual 1-forms to Primal 2-forms.
 d2 = d(2,sd)
 wpd = dec_wedge_product_pd(Val(2), Val(1), sd)
-s3 = ⋆(Val{3}, sd, DiagonalHodge())
-is3 = inv_hodge_star(Val{3}, sd, DiagonalHodge()) # From Dual 0-forms to Primal 3-forms.
+s3 = ⋆(Val(3), sd, DiagonalHodge())
+is3 = inv_hodge_star(Val(3), sd, DiagonalHodge()) # From Dual 0-forms to Primal 3-forms.
 
 dual_div = s3 * d2 * is2
 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -685,20 +685,22 @@ rel_error(C,D,k) = abs_error(C,D,k) / norm(k)
 
 @test rel_error(C, C_adv, 1) < 0.5
 
-# Lie derivative formulation: ∂_t C = -L_v C = -i_v(dC) = -(-1)^(k(n-k)) ⋆(⋆(dC) ∧ v♭)
-# For k=1, n=3: (-1)^(1*2) = 1, so ∂_t C = -⋆(⋆(dC) ∧ v♭) = -s3(is2(dC) ∧ dZ)
-function lie_3D_timestep!(dtC, C, dZ, k, s3, wpd, is2, dd0)
-  dtC .= -k * s3 * wpd(is2 * dd0 * C, dZ)
+# Lie derivative on a dual 0-form: L_v C = ∇·(Cv) - C(∇·v)
+# i.e. ∂_t C = -L_v C = -∇·(Cv) + C(∇·v)
+# The first term is the advection (divergence form), and the second is a correction.
+div_v = dual_div * dZ  # ∇·v as a dual 0-form
+function lie_3D_timestep!(dtC, C, dZ, k, dual_div, wdd, div_v)
+  dtC .= k * (-(dual_div * wdd(C, dZ)) .+ C .* div_v)
 end
 
-function midpoint_method_lie!(C, dZ, k, s3, wpd, is2, dd0)
+function midpoint_method_lie!(C, dZ, k, dual_div, wdd, div_v)
   dt = 1e-5
   dtC = zeros(length(C))
   dC = zeros(length(C))
   for _ in 1:1e5
-    lie_3D_timestep!(dC, C, dZ, k, s3, wpd, is2, dd0)
+    lie_3D_timestep!(dC, C, dZ, k, dual_div, wdd, div_v)
     dC[b_tets] .= 0.0
-    lie_3D_timestep!(dtC, C .+ (dt/2 * dC), dZ, k, s3, wpd, is2, dd0)
+    lie_3D_timestep!(dtC, C .+ (dt/2 * dC), dZ, k, dual_div, wdd, div_v)
     C .+= dt * dtC
     C[b_tets] .= 0.0
   end
@@ -706,8 +708,8 @@ function midpoint_method_lie!(C, dZ, k, s3, wpd, is2, dd0)
 end
 
 C[b_tets] .= 0.0
-k = 1e-3
-C_lie = midpoint_method_lie!(copy(C), dZ, k, s3, wpd, is2, dd0)
+k = 1
+C_lie = midpoint_method_lie!(copy(C), dZ, k, dual_div, wdd, div_v)
 
 @test rel_error(C, C_lie, k) < 0.5
 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -565,10 +565,13 @@ sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s);
 subdivide_duals!(sd, Barycenter());
 
 dd0 = dual_derivative(0,sd)
+dd1 = dual_derivative(1,sd)
 wdd = dec_wedge_product_dd(Tuple{0,1}, sd)
 is2 = inv_hodge_star(Val{2}, sd, DiagonalHodge()) # From Dual 1-forms to Primal 2-forms.
 d2 = d(2,sd)
 wpd = dec_wedge_product_pd(Tuple{2,1}, sd)
+s2 = ⋆(Val{2}, sd, DiagonalHodge())
+is2 = inv_hodge_star(Val{2}, sd, DiagonalHodge()) # From Dual 1-forms to Primal 2-forms.
 s3 = ⋆(Val{3}, sd, DiagonalHodge())
 # TODO: Upstream sign currying.
 s3.diag .*= sign(3,sd)
@@ -588,6 +591,65 @@ end
 
 # This is a dual 1-form, which encodes a constant gradient pointing "up".
 dZ = dd0 * (sign(3,sd) .* map(x -> x[3], sd[sd[:tet_center], :dual_point]))
+
+# This is a primal 2-form, encoding (signed) unit areas parallel to the z=0 plane.
+dXdY = map(triangles(sd)) do tri
+  e1, e2, _ = triangle_edges(sd,tri)
+  e1_vec, e2_vec = as_vec(sd,e1), as_vec(sd,e2)
+  (cross(e1_vec, e2_vec) * sign(2,sd,tri))[3] / 2
+  # Note that normalizing is the same as dividing by 2*sd[tri, :area],
+  # so the above is equivalent to:
+  #n = normalize(cross(e1_vec, e2_vec) * sign(2,sd,tri))
+  #sd[tri, :area] * n[3] # i.e. n ⋅ SVector{3,Float64}(0,0,1)
+end
+
+@test std(is2*dZ - dXdY) < 8.0
+
+#=
+julia> histogram((is2*dZ - dXdY), nbins=20)
+                  ┌                                        ┐ 
+   [-35.0, -30.0) ┤▏ 2                                       
+   [-30.0, -25.0) ┤▎ 4                                       
+   [-25.0, -20.0) ┤▊ 31                                      
+   [-20.0, -15.0) ┤██▌ 83                                    
+   [-15.0, -10.0) ┤█████▌ 187                                
+   [-10.0,  -5.0) ┤███████████▉ 410                          
+   [ -5.0,   0.0) ┤█████████████████████████████████  1 130  
+   [  0.0,   5.0) ┤██████████████████████████████▌ 1 045     
+   [  5.0,  10.0) ┤████████▉ 308                             
+   [ 10.0,  15.0) ┤█████▋ 196                                
+   [ 15.0,  20.0) ┤██▊ 99                                    
+   [ 20.0,  25.0) ┤▊ 31                                      
+   [ 25.0,  30.0) ┤▍ 10                                      
+   [ 30.0,  35.0) ┤▏ 1                                       
+                  └                                        ┘ 
+                                   Frequency                 
+
+julia> histogram((is2*dZ - dXdY).^2, nbins=20)
+                    ┌                                        ┐ 
+   [   0.0,   50.0) ┤█████████████████████████████████  2 512  
+   [  50.0,  100.0) ┤█████▏ 381                                
+   [ 100.0,  150.0) ┤██▋ 201                                   
+   [ 150.0,  200.0) ┤█▋ 133                                    
+   [ 200.0,  250.0) ┤█▍ 97                                     
+   [ 250.0,  300.0) ┤▊ 59                                      
+   [ 300.0,  350.0) ┤▋ 46                                      
+   [ 350.0,  400.0) ┤▍ 29                                      
+   [ 400.0,  450.0) ┤▍ 21                                      
+   [ 450.0,  500.0) ┤▍ 20                                      
+   [ 500.0,  550.0) ┤▎ 11                                      
+   [ 550.0,  600.0) ┤▎ 9                                       
+   [ 600.0,  650.0) ┤▏ 3                                       
+   [ 650.0,  700.0) ┤▏ 1                                       
+   [ 700.0,  750.0) ┤▏ 6                                       
+   [ 750.0,  800.0) ┤▏ 2                                       
+   [ 800.0,  850.0) ┤▏ 1                                       
+   [ 850.0,  900.0) ┤▏ 2                                       
+   [ 900.0,  950.0) ┤▏ 2                                       
+   [ 950.0, 1000.0) ┤▏ 1                                       
+                    └                                        ┘ 
+                                     Frequency                 
+=#
 
 # Demonstrate advection in 3D using the midpoint method.
 function advection_3D_timestep!(dtC, C, dZ, k, dual_div, wdd)
@@ -625,6 +687,7 @@ displacement(C,C_adv)
 abs_error(C,C_adv,k)
 rel_error(C,C_adv,k)
 
+b_tris = boundary_inds(Val{2}, sd)
 b_tets = boundary_inds(Val{3}, sd)
 
 s2sd = sign(2,sd)

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -568,6 +568,7 @@ dd0 = dual_derivative(0,sd)
 wdd = dec_wedge_product_dd(Tuple{0,1}, sd)
 is2 = inv_hodge_star(Val{2}, sd, DiagonalHodge()) # From Dual 1-forms to Primal 2-forms.
 d2 = d(2,sd)
+wpd = dec_wedge_product_pd(Tuple{2,1}, sd)
 s3 = ⋆(Val{3}, sd, DiagonalHodge())
 # TODO: Upstream sign currying.
 s3.diag .*= sign(3,sd)
@@ -582,7 +583,7 @@ nrml = MvNormal(μ, I(3))
 # Taking the inverse hodge star would multiply by the sign of the tetrahedron, and multiply by the volume,
 # which would give a Primal 3-form of the mass stored in each tetrahedron.
 C = map(sign(3,sd), sd[sd[:tet_center], :dual_point]) do sgn,p
-  norm(p - μ) ≤ 1.0 ? sgn * 15.8 * pdf(nrml,p) : 0.0
+  norm(p - μ) ≤ 3.0 ? sgn * 15.8 * pdf(nrml,p) : 0.0
 end
 
 # This is a dual 1-form, which encodes a constant gradient pointing "up".
@@ -593,7 +594,7 @@ function advection_3D_timestep!(dtC, C, dZ, k, dual_div, wdd)
   dtC .= dual_div * (k * wdd(C, dZ))
 end
 
-function midpoint_method!(C, dZ, k, dual_div, wdd)
+function midpoint_method_advection!(C, dZ, k, dual_div, wdd)
   dt = 1e-5
   dtC = zeros(length(C))
   dC = zeros(length(C))
@@ -606,7 +607,7 @@ function midpoint_method!(C, dZ, k, dual_div, wdd)
 end
 
 k = 1
-C_midpt = midpoint_method!(copy(C), dZ, k, dual_div, wdd)
+C_adv = midpoint_method_advection!(copy(C), dZ, k, dual_div, wdd)
 
 # In 1 second, the center of mass move should move by approximately k.
 function center_of_mass(D)
@@ -617,8 +618,36 @@ displacement(C,D) = center_of_mass(D) - center_of_mass(C)
 abs_error(C,D,k) = norm(displacement(C,D) - SVector{3,Float64}(0,0,k))
 rel_error(C,D,k) = abs_error(C,D,k) / norm(k)
 
-displacement(C,C_midpt)
-abs_error(C,C_midpt,k)
-rel_error(C,C_midpt,k)
+displacement(C,C_adv)
+abs_error(C,C_adv,k)
+rel_error(C,C_adv,k)
+
+# TODO: Upstream the rest of this Lie derivative.
+# -1^(k(n-k)) star(star(a) wedge X)
+# where a = d(C) = Dual 1-Form, n=3, and k=1.
+# s3(is2(a) wedge_primal2_dual1 X)
+function lie_3D_timestep!(dtC, C, dZ, k, s3, wpd, is2, dd0)
+  dtC .= k * s3 * wpd(is2 * dd0 * C, dZ)
+end
+
+function midpoint_method_lie!(C, dZ, k, s3, wpd, is2, dd0)
+  dt = 1e-5
+  dtC = zeros(length(C))
+  dC = zeros(length(C))
+  for _ in 1:1e5
+    lie_3D_timestep!(dtC, C, dZ, k, s3, wpd, is2, dd0)
+    lie_3D_timestep!(dtC, C .+ (dt/2 * dC), dZ, k, s3, wpd, is2, dd0)
+    C .+= dt * dtC
+  end
+  C
+end
+
+k = 1e-3
+C_lie = midpoint_method_lie!(copy(C), dZ, k, s3, wpd, is2, dd0)
+
+displacement(C,C_lie)
+abs_error(C,C_lie,k)
+rel_error(C,C_lie,k)
 
 end
+

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -662,7 +662,7 @@ function midpoint_method_advection!(C, dZ, k, dual_div, wdd)
   dt = 1e-5
   dtC = zeros(length(C))
   dC = zeros(length(C))
-  for _ in 1:1e5
+  for _ in 1:100_000
     advection_3D_timestep!(dC, C, dZ, k, dual_div, wdd)
     dC[b_tets] .= 0.0
     advection_3D_timestep!(dtC, C .+ (dt/2 * dC), dZ, k, dual_div, wdd)
@@ -702,7 +702,7 @@ function midpoint_method_lie!(C, dZ, k, dual_div, wdd, div_v)
   dt = 1e-5
   dtC = zeros(length(C))
   dC = zeros(length(C))
-  for _ in 1:1e5
+  for _ in 1:100_000
     lie_3D_timestep!(dC, C, dZ, k, dual_div, wdd, div_v)
     dC[b_tets] .= 0.0
     lie_3D_timestep!(dtC, C .+ (dt/2 * dC), dZ, k, dual_div, wdd, div_v)

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -5,13 +5,17 @@ using SparseArrays
 using LinearAlgebra
 using Catlab
 using CombinatorialSpaces
-using CombinatorialSpaces.CombMeshes: tri_345, tri_345_false, grid_345, right_scalene_unit_hypot, single_tetrahedron
+using CombinatorialSpaces.CombMeshes: tri_345, tri_345_false, grid_345, right_scalene_unit_hypot, single_tetrahedron, tetgen_readme_mesh, parallelepiped
 using CombinatorialSpaces.SimplicialSets: boundary_inds
 using CombinatorialSpaces.DiscreteExteriorCalculus: eval_constant_primal_form
 using GeometryBasics: Point, QuadFace, MetaMesh
 using Random
+using Distributions
 using StaticArrays: SVector
 using Statistics: mean, var, std
+
+Point2D = Point2{Float64}
+Point3D = Point3{Float64}
 
 Random.seed!(0)
 
@@ -553,5 +557,68 @@ end
     x*x
   end)[interior_tris])
 end
+
+# 3D Operations
+#--------------
+s = tetgen_readme_mesh();
+sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3D}(s);
+subdivide_duals!(sd, Barycenter());
+
+dd0 = dual_derivative(0,sd)
+wdd = dec_wedge_product_dd(Tuple{0,1}, sd)
+is2 = inv_hodge_star(Val{2}, sd, DiagonalHodge()) # From Dual 1-forms to Primal 2-forms.
+d2 = d(2,sd)
+s3 = ⋆(Val{3}, sd, DiagonalHodge())
+# TODO: Upstream sign currying.
+s3.diag .*= sign(3,sd)
+is3 = inv_hodge_star(Val{3}, sd, DiagonalHodge()) # From Dual 0-forms to Primal 3-forms.
+is3.diag .*= sign(3,sd)
+
+dual_div = s3 * d2 * is2
+
+μ = Point3D(1,1,6)
+nrml = MvNormal(μ, I(3))
+# This is a dual 0-form. It has units of (signed) mass density [M L^⁻³].
+# Taking the inverse hodge star would multiply by the sign of the tetrahedron, and multiply by the volume,
+# which would give a Primal 3-form of the mass stored in each tetrahedron.
+C = map(sign(3,sd), sd[sd[:tet_center], :dual_point]) do sgn,p
+  norm(p - μ) ≤ 1.0 ? sgn * 15.8 * pdf(nrml,p) : 0.0
+end
+
+# This is a dual 1-form, which encodes a constant gradient pointing "up".
+dZ = dd0 * (sign(3,sd) .* map(x -> x[3], sd[sd[:tet_center], :dual_point]))
+
+# Demonstrate advection in 3D using the midpoint method.
+function advection_3D_timestep!(dtC, C, dZ, k, dual_div, wdd)
+  dtC .= dual_div * (k * wdd(C, dZ))
+end
+
+function midpoint_method!(C, dZ, k, dual_div, wdd)
+  dt = 1e-5
+  dtC = zeros(length(C))
+  dC = zeros(length(C))
+  for _ in 1:1e5
+    advection_3D_timestep!(dC, C, dZ, k, dual_div, wdd)
+    advection_3D_timestep!(dtC, C .+ (dt/2 * dC), dZ, k, dual_div, wdd)
+    C .+= dt * dtC
+  end
+  C
+end
+
+k = 1
+C_midpt = midpoint_method!(copy(C), dZ, k, dual_div, wdd)
+
+# In 1 second, the center of mass move should move by approximately k.
+function center_of_mass(D)
+  mass = is3 * D
+  sum(mass .* (sd[sd[:tet_center], :dual_point])) / sum(mass)
+end
+displacement(C,D) = center_of_mass(D) - center_of_mass(C)
+abs_error(C,D,k) = norm(displacement(C,D) - SVector{3,Float64}(0,0,k))
+rel_error(C,D,k) = abs_error(C,D,k) / norm(k)
+
+displacement(C,C_midpt)
+abs_error(C,C_midpt,k)
+rel_error(C,C_midpt,k)
 
 end

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -605,6 +605,10 @@ end
 
 @test std(is2*dZ - dXdY) < 8.0
 
+# Test that dZ is closed.
+@test all(abs.(dd1*dZ) .< 1e-14)
+# Test that dXdY is closed.
+@test all(abs.(d2*dXdY) .< 1e-15)
 #=
 julia> histogram((is2*dZ - dXdY), nbins=20)
                   ┌                                        ┐ 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,0 @@
-[deps]
-CombinatorialSpaces = "b1c52339-7909-45ad-8b6a-6e388f7c67f2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+CombinatorialSpaces = "b1c52339-7909-45ad-8b6a-6e388f7c67f2"


### PR DESCRIPTION
PR #57 and PR #60 implemented the 3D DEC, and demonstrated the differential operators in solving the heat equation, i.e. a diffusion problem.

However, a demonstration of advection was not performed.

So, this branch is meant to demonstrate such a simulation. It implements a dual-dual 0-1 wedge product and a primal-dual 2-1 wedge product. A Lie derivative operation is then defined by composing operators. These are all implemented as matrix-vector operations.

Since this branch was last edited, PR #163 introduced a primal-primal 1-1 wedge product, which could be of utility in a similar advection problem. Note that that PR does not use a kernel or matrix version of that operation.