### PR TITLE
Add dual Laplacian for 1D and 3D

### DIFF
--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -625,10 +625,11 @@ function Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet2D)
 end
 
 function Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet3D)
-  dd0 = dec_dual_derivative(0, s);
-  ihs1 = dec_inv_hodge_star(2, s, GeometricHodge());
-  d1 = dec_differential(2,s);
-  hs2 = dec_hodge_star(3, s, GeometricHodge());
+  # TODO: These elementary operations should be defined in this module.
+  dd0 = dual_derivative(0, s);
+  ihs1 = inv_hodge_star(2, s, DiagonalHodge());
+  d1 = d(2,s);
+  hs2 = hodge_star(3, s, DiagonalHodge());
   m = hs2 * d1
   x -> hs2 * d1 * ihs1 * dd0 * x
 end

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -1082,6 +1082,21 @@ function interior(::Type{Val{0}}, s::HasDeltaSet2D)
   setdiff(vertices(s), boundaries)
 end
 
+function boundary_inds(::Type{Val{3}}, s::HasDeltaSet3D)
+  # A tetrahedron is on the boundary if any of its triangles a face of that tetrahedron alone.
+  filter(tetrahedra(s)) do tet
+    tris = tetrahedron_triangles(s, tet)
+    any(map(tris) do t
+      tets = union(reduce(vcat,
+                   [incident(s, t, :∂t0)...,
+                    incident(s, t, :∂t1)...,
+                    incident(s, t, :∂t2)...,
+                    incident(s, t, :∂t3)...]))
+      length(tets) == 1
+    end)
+  end
+end
+
 # REPL IO
 #########
 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -8,9 +8,11 @@ using CombinatorialSpaces
 using CombinatorialSpaces.Meshes: tri_345, tri_345_false, grid_345, right_scalene_unit_hypot
 using CombinatorialSpaces.SimplicialSets: boundary_inds
 using CombinatorialSpaces.DiscreteExteriorCalculus: eval_constant_primal_form
+using GeometryBasics: Point, QuadFace, MetaMesh
 using Random
 using StaticArrays: SVector
-using Statistics: mean, var
+using Statistics: mean, var, std
+using TetGen
 
 Random.seed!(0)
 
@@ -61,6 +63,29 @@ rect = EmbeddedDeltaDualComplex2D{Bool,Float64,Point3d}(rect′);
 subdivide_duals!(rect, Barycenter());
 
 flat_meshes = [tri_345()[2], tri_345_false()[2], right_scalene_unit_hypot()[2], grid_345()[2], tg, rect];
+
+# Create mesh from the TetGen.jl/README.md.
+# https://github.com/JuliaGeometry/TetGen.jl/blob/ea73adce3ea4dfa6062eb84b1eff05f3fcab60a5/README.md
+function tetgen_readme_mesh()
+  points = Point{3, Float64}[
+    (0.0, 0.0, 0.0), (2.0, 0.0, 0.0),
+    (2.0, 2.0, 0.0), (0.0, 2.0, 0.0),
+    (0.0, 0.0, 12.0), (2.0, 0.0, 12.0),
+    (2.0, 2.0, 12.0), (0.0, 2.0, 12.0)]
+  facets = QuadFace{Cint}[
+    1:4, 5:8,
+    [1,5,6,2],
+    [2,6,7,3],
+    [3, 7, 8, 4],
+    [4, 8, 5, 1]]
+  markers = Cint[-1, -2, 0, 0, 0, 0]
+  mesh = MetaMesh(points, facets; markers)
+  mesh, tetrahedralize(mesh, "Qvpq1.414a0.1");
+end
+_, tet_msh = tetgen_readme_mesh()
+tet_msh = EmbeddedDeltaSet3D(tet_msh)
+tet_msh_sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3d}(tet_msh)
+subdivide_duals!(tet_msh_sd, Circumcenter())
 
 @testset "Exterior Derivative" begin
     for i in 0:0
@@ -201,6 +226,37 @@ end
 
         @test all(dec_wedge_product(Tuple{1, 1}, sd)(E_1, E_2) .≈ ∧(Tuple{1, 1}, sd, E_1, E_2))
     end
+end
+
+@testset "Dual Laplacian" begin
+  # Test basic calculus properties on the interior of the mesh:
+  # The second derivative of a linear function is 0.
+
+  # 1D
+  primal_line = EmbeddedDeltaSet1D{Bool,Point2d}()
+  add_vertices!(primal_line, 400, point=map(p -> Point2D(p,0), range(0,10;length=400)))
+  add_edges!(primal_line, 1:399, 2:400)
+  sd = generate_dual_mesh(primal_line)
+  twoX = map(p -> 2*p[1], sd[sd[:edge_center], :dual_point])
+  nil = Δᵈ(Val{0}, sd)(twoX)
+  @test all(abs.(nil[begin+1:end-1]) .< 1e-11)
+
+  # 2D
+  for sd in [tg, rect]
+    twoX = map(p -> 2*p[1], sd[sd[:tri_center], :dual_point])
+    nil = Δᵈ(Val{0}, sd)(twoX)
+    interior_tris = setdiff(triangles(sd), boundary_inds(Val{2}, sd))
+    @test abs(mean(nil[interior_tris])) < 1e-13
+    @test std(nil[interior_tris]) < 0.31
+  end
+
+  # 3D
+  sd = tet_msh_sd
+  twoX = map(p -> 2*p[1], sd[sd[:tet_center], :dual_point])
+  nil = Δᵈ(Val{0}, sd)(twoX)
+  interior_tets = setdiff(tetrahedra(sd), boundary_inds(Val{3}, sd))
+  @test abs(mean(nil[interior_tets])) < 0.03
+  @test std(nil[interior_tets]) < 6.7
 end
 
 @testset "Averaging Operator" begin


### PR DESCRIPTION
The current dual Laplacian operator in the FastDEC module is written for the 2D simplicial complex case. Most simulations target the 2D DEC, and the corresponding operator for 1D and 3D can be quickly defined.

However, this can result in code duplication downstream, and those script definitions can go un-tested.

So, I am upstreaming these operators in this short PR. This should result in a patch release.