### PR TITLE
3D Parallelepiped Mesh

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+TetGen = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -65,7 +66,6 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TetGen = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"
 
 [targets]
-test = ["CairoMakie", "CUDA", "Pkg", "Random", "Test", "Statistics", "TetGen"]
+test = ["CairoMakie", "CUDA", "Pkg", "Random", "Test", "Statistics"]


### PR DESCRIPTION
This PR is meant to add a 3D parallelepiped mesh that uses TetGen under the hood for easy subdivision. An example of such a mesh is shown below. Note the different side lengths set as well as the shift in the top face relative to the bottom face.
![tetmesh](https://github.com/user-attachments/assets/ce335bb4-8f71-4ce9-a0b2-68740590a4da)
