### PR TITLE
Move TetGen README mesh to src

### DIFF
--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -14,7 +14,6 @@ using LinearAlgebra: Diagonal, mul!, norm, dot, cross
 using SparseArrays
 using StaticArrays
 using Statistics: mean, median
-using TetGen
 
 # 1D dual complex
 #################
@@ -1000,27 +999,7 @@ dZ = d0 * map(p -> p[3], s[:point])
 
 # Test the 2-1 wedge product on a larger mesh.
 
-# Create the mesh from the TetGen.jl/README.md.
-# https://github.com/JuliaGeometry/TetGen.jl/blob/ea73adce3ea4dfa6062eb84b1eff05f3fcab60a5/README.md
-function tetgen_readme_mesh()
-  points = Point{3, Float64}[
-    (0.0, 0.0, 0.0), (2.0, 0.0, 0.0),
-    (2.0, 2.0, 0.0), (0.0, 2.0, 0.0),
-    (0.0, 0.0, 12.0), (2.0, 0.0, 12.0),
-    (2.0, 2.0, 12.0), (0.0, 2.0, 12.0)]
-  facets = QuadFace{Cint}[
-    1:4, 5:8,
-    [1,5,6,2],
-    [2,6,7,3],
-    [3, 7, 8, 4],
-    [4, 8, 5, 1]]
-  markers = Cint[-1, -2, 0, 0, 0, 0]
-  mesh = MetaMesh(points, facets; markers)
-  mesh, tetrahedralize(mesh, "Qvpq1.414a0.1");
-end
-msh, tet_msh = tetgen_readme_mesh()
-
-primal_s = EmbeddedDeltaSet3D(tet_msh)
+primal_s = tetgen_readme_mesh()
 s = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3d}(primal_s)
 subdivide_duals!(s, Barycenter())
 

--- a/test/MeshInterop.jl
+++ b/test/MeshInterop.jl
@@ -51,23 +51,20 @@ sd_to_mesh = Mesh(sd)
 #---------------------
 # Create mesh from the TetGen.jl/README.md.
 # https://github.com/JuliaGeometry/TetGen.jl/blob/ea73adce3ea4dfa6062eb84b1eff05f3fcab60a5/README.md
-function tetgen_readme_mesh()
-  points = Point{3, Float64}[
-    (0.0, 0.0, 0.0), (2.0, 0.0, 0.0),
-    (2.0, 2.0, 0.0), (0.0, 2.0, 0.0),
-    (0.0, 0.0, 12.0), (2.0, 0.0, 12.0),
-    (2.0, 2.0, 12.0), (0.0, 2.0, 12.0)]
-  facets = QuadFace{Cint}[
-    1:4, 5:8,
-    [1,5,6,2],
-    [2,6,7,3],
-    [3, 7, 8, 4],
-    [4, 8, 5, 1]]
-  markers = Cint[-1, -2, 0, 0, 0, 0]
-  mesh = GeometryBasics.MetaMesh(points, facets; markers)
-  mesh, tetrahedralize(mesh, "Qvpq1.414a0.1");
-end
-msh, tet_msh = tetgen_readme_mesh()
+points = Point{3, Float64}[
+  (0.0, 0.0, 0.0), (2.0, 0.0, 0.0),
+  (2.0, 2.0, 0.0), (0.0, 2.0, 0.0),
+  (0.0, 0.0, 12.0), (2.0, 0.0, 12.0),
+  (2.0, 2.0, 12.0), (0.0, 2.0, 12.0)]
+facets = QuadFace{Cint}[
+  1:4, 5:8,
+  [1,5,6,2],
+  [2,6,7,3],
+  [3, 7, 8, 4],
+  [4, 8, 5, 1]]
+markers = Cint[-1, -2, 0, 0, 0, 0]
+msh = GeometryBasics.MetaMesh(points, facets; markers)
+tet_msh = tetrahedralize(msh, "Qvpq1.414a0.1")
 
 # Import.
 s = EmbeddedDeltaSet3D(tet_msh)

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -12,7 +12,6 @@ using GeometryBasics: Point, QuadFace, MetaMesh
 using Random
 using StaticArrays: SVector
 using Statistics: mean, var, std
-using TetGen
 
 Random.seed!(0)
 
@@ -64,26 +63,7 @@ subdivide_duals!(rect, Barycenter());
 
 flat_meshes = [tri_345()[2], tri_345_false()[2], right_scalene_unit_hypot()[2], grid_345()[2], tg, rect];
 
-# Create mesh from the TetGen.jl/README.md.
-# https://github.com/JuliaGeometry/TetGen.jl/blob/ea73adce3ea4dfa6062eb84b1eff05f3fcab60a5/README.md
-function tetgen_readme_mesh()
-  points = Point{3, Float64}[
-    (0.0, 0.0, 0.0), (2.0, 0.0, 0.0),
-    (2.0, 2.0, 0.0), (0.0, 2.0, 0.0),
-    (0.0, 0.0, 12.0), (2.0, 0.0, 12.0),
-    (2.0, 2.0, 12.0), (0.0, 2.0, 12.0)]
-  facets = QuadFace{Cint}[
-    1:4, 5:8,
-    [1,5,6,2],
-    [2,6,7,3],
-    [3, 7, 8, 4],
-    [4, 8, 5, 1]]
-  markers = Cint[-1, -2, 0, 0, 0, 0]
-  mesh = MetaMesh(points, facets; markers)
-  mesh, tetrahedralize(mesh, "Qvpq1.414a0.1");
-end
-_, tet_msh = tetgen_readme_mesh()
-tet_msh = EmbeddedDeltaSet3D(tet_msh)
+tet_msh = tetgen_readme_mesh()
 tet_msh_sd = EmbeddedDeltaDualComplex3D{Bool, Float64, Point3d}(tet_msh)
 subdivide_duals!(tet_msh_sd, Circumcenter())
 


### PR DESCRIPTION
As mentioned in the review of PR #169 , move the TetGen README mesh introduced in PR #100 from tests to src, due to repeated usage and the addition of TetGen as a direct dependency.