### PR TITLE
Add support for DelaunayTriangulation.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,10 +28,12 @@ TetGen = "c5d3f3f7-f850-59f6-8a2e-ffc6dc1317ea"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+DelaunayTriangulation = "927a84f5-c5f4-47a5-9785-b46e178433df"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
 CombinatorialSpacesCUDAExt = "CUDA"
+CombinatorialSpacesDelaunayTriangulationExt = "DelaunayTriangulation"
 CombinatorialSpacesMakieExt = "Makie"
 
 [compat]
@@ -39,6 +41,7 @@ ACSets = "0.2"
 Artifacts = "1.9, 1"
 CUDA = "5.2"
 Catlab = "0.16.20"
+DelaunayTriangulation = "1.6.4"
 FileIO = "^1"
 GATlab = "0.1.5"
 GeometryBasics = "0.5"
@@ -62,10 +65,11 @@ julia = "1.10"
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+DelaunayTriangulation = "927a84f5-c5f4-47a5-9785-b46e178433df"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CairoMakie", "CUDA", "Pkg", "Random", "Test", "Statistics"]
+test = ["CairoMakie", "CUDA", "DelaunayTriangulation", "Pkg", "Random", "Test", "Statistics"]

--- a/ext/CombinatorialSpacesDelaunayTriangulationExt.jl
+++ b/ext/CombinatorialSpacesDelaunayTriangulationExt.jl
@@ -6,6 +6,7 @@ import CombinatorialSpaces: EmbeddedDeltaSet2D
 import DelaunayTriangulation: number_type
 
 function EmbeddedDeltaSet2D(triangulation::T) where {T<:DelaunayTriangulation.Triangulation}
+  @warn "EmbeddedDeltaSet2D mesh will use 3D points, setting z-coordinate to 0"
   float_type = number_type(triangulation.points)
   coords = map(p -> Point3{float_type}(p[1], p[2], 0), triangulation.points)
 

--- a/ext/CombinatorialSpacesDelaunayTriangulationExt.jl
+++ b/ext/CombinatorialSpacesDelaunayTriangulationExt.jl
@@ -1,0 +1,19 @@
+module CombinatorialSpacesDelaunayTriangulationExt
+using CombinatorialSpaces
+using DelaunayTriangulation
+
+import CombinatorialSpaces: EmbeddedDeltaSet2D
+
+function EmbeddedDeltaSet2D(triangulation::T) where {T<:DelaunayTriangulation.Triangulation}
+  coords = triangulation.points
+  s = EmbeddedDeltaSet2D{Bool, eltype(coords)}()
+  add_vertices!(s, length(coords), point=coords)
+  for tri in each_solid_triangle(triangulation)
+    glue_sorted_triangle!(s, tri...)
+  end
+  s[:edge_orientation] = false
+  orient!(s)
+  s
+end
+
+end

--- a/ext/CombinatorialSpacesDelaunayTriangulationExt.jl
+++ b/ext/CombinatorialSpacesDelaunayTriangulationExt.jl
@@ -5,8 +5,9 @@ using DelaunayTriangulation
 import CombinatorialSpaces: EmbeddedDeltaSet2D
 
 function EmbeddedDeltaSet2D(triangulation::T) where {T<:DelaunayTriangulation.Triangulation}
-  coords = triangulation.points
-  s = EmbeddedDeltaSet2D{Bool, eltype(coords)}()
+  float_type = eltype(first(first(triangulation.points)))
+  coords = map(p -> Point3{float_type}(p[1], p[2], 0), triangulation.points)
+  s = EmbeddedDeltaSet2D{Bool, Point3{float_type}}()
   add_vertices!(s, length(coords), point=coords)
   for tri in each_solid_triangle(triangulation)
     glue_sorted_triangle!(s, tri...)

--- a/ext/CombinatorialSpacesDelaunayTriangulationExt.jl
+++ b/ext/CombinatorialSpacesDelaunayTriangulationExt.jl
@@ -3,10 +3,12 @@ using CombinatorialSpaces
 using DelaunayTriangulation
 
 import CombinatorialSpaces: EmbeddedDeltaSet2D
+import DelaunayTriangulation: number_type
 
 function EmbeddedDeltaSet2D(triangulation::T) where {T<:DelaunayTriangulation.Triangulation}
-  float_type = eltype(first(first(triangulation.points)))
+  float_type = number_type(triangulation.points)
   coords = map(p -> Point3{float_type}(p[1], p[2], 0), triangulation.points)
+
   s = EmbeddedDeltaSet2D{Bool, Point3{float_type}}()
   add_vertices!(s, length(coords), point=coords)
   for tri in each_solid_triangle(triangulation)


### PR DESCRIPTION
This PR adds a small interop function for the [DelaunayTriangulation.jl](https://github.com/JuliaGeometry/DelaunayTriangulation.jl) package. A user would be expected to use DelaunayTriangulation to generate a specific 2D mesh that they desire and then use the interop function to port it to an `EmbeddedDeltaSet2D`. 

The advantages are the ability to quickly generate a mesh given only a set of desired points, have it be Delaunay (which is shown to work well in general for DEC), and allow for mesh refinement (both unconstrained and constrained). 

This PR only adds DelaunayTriangulation as an extension so there is no downside for users not using this feature.