### PR TITLE
Added new triangulated_grid method

### DIFF
--- a/src/Meshes.jl
+++ b/src/Meshes.jl
@@ -135,13 +135,18 @@ end
 
 """    triangulated_grid(lx::Real, ly::Real, nx::Int, ny::Int; point_type::DataType = Point3d, compress::Bool=true)
 
-Triangulate the rectangle [0,lx] x [0,ly] with `nx` by `ny` approximately equilateral triangles. This results
-in a mesh containing `2*nx*ny` triangles.
+Generate a rectangle [0,lx] x [0,ly] with `nx+1` by `ny+1` vertices. This results in a mesh containing `2*nx*ny` triangles.
+Setting the `dx` or `dy` keywords will override the respective `nx` or `ny` keywords.
 """
-function triangulated_grid(lx::Real, ly::Real, nx::Int, ny::Int; point_type::DataType = Point3d, compress::Bool=true)
+function triangulated_grid(lx::Real, ly::Real; nx::Int = 10, ny::Int = 10, dx::Real = 0, dy::Real = 0, point_type::DataType = Point3d, compress::Bool = true)
   @assert lx > 0 && ly > 0
   @assert nx > 0 && ny > 0
-  triangulated_grid(lx, ly, lx / nx, ly / ny, point_type, compress)
+  @assert dx >= 0 && dy >= 0
+
+  arg_dx = dx != 0 ? dx : lx / nx
+  arg_dy = dy != 0 ? dy : ly / ny
+
+  triangulated_grid(lx, ly, arg_dx, arg_dy, point_type, compress)
 end
 
 """    function mirrored_mesh()
@@ -153,7 +158,7 @@ function mirrored_mesh(lx, ly)
   lx, ly = 40.0, 20.0
   xs = range(0, lx; length = 3)
   ys = range(0, ly; length = 3)
-  
+
   add_vertices!(s, 9)
   i = 1
   for y in ys
@@ -427,7 +432,7 @@ end
 
 Uses TetGen to generate turn a specificed parallelepiped to a tetrahedralized mesh. `lx`, `ly`, and `lz` kwargs control the side lengths in the respective dimensions and `dx` and `dy` kwargs will translate the top face relative to the bottom face.
 
-Default TetGen command is "pQq1.414a0.1" and user desired cmds can be passed through the `tetcmd` kwarg. 
+Default TetGen command is "pQq1.414a0.1" and user desired cmds can be passed through the `tetcmd` kwarg.
 """
 function parallelepiped(;lx::Real = 1.0, ly::Real = 1.0, lz::Real = 1.0, dx::Real = 0.0, dy::Real = 0.0, point_type = Point3d, tetcmd::String = "pQq1.414a0.1")
 	points = point_type[
@@ -478,4 +483,3 @@ function tetgen_readme_mesh()
 end
 
 end
-

--- a/test/Meshes.jl
+++ b/test/Meshes.jl
@@ -137,15 +137,19 @@ s = triangulated_grid(lx, 2, 1, 0.99, Point2{Float64}, true)
 test_trigrid_size(s, lx, 2, 1, 0.99)
 @test maximum(getindex.(s[:point], 1)) == lx
 
-@test triangulated_grid(10, 10, 1, 1, Point3d) == triangulated_grid(10, 10, 10, 10)
-@test triangulated_grid(10, 10, 1, 1, Point3d, false) == triangulated_grid(10, 10, 10, 10; compress = false)
-@test triangulated_grid(10, 10, 1, 1, Point2d) == triangulated_grid(10, 10, 10, 10; point_type = Point2d)
-nx = 15; ny = 20
-@test ntriangles(triangulated_grid(10, 10, nx, ny)) == 2*nx*ny
-@test ntriangles(triangulated_grid(1, 5, nx, ny)) == 2*nx*ny
+@test triangulated_grid(10, 10, 1, 1, Point3d) == triangulated_grid(10, 10; nx=10, ny=10)
+@test triangulated_grid(10, 10, 1, 1, Point3d, false) == triangulated_grid(10, 10; nx=10, ny=10, compress = false)
+@test triangulated_grid(10, 10, 1, 1, Point2d) == triangulated_grid(10, 10; nx=10, ny=10, point_type = Point2d)
+@test triangulated_grid(10, 10, 1, 1, Point3d) == triangulated_grid(10, 10; dx=1, dy=1, point_type = Point3d)
+@test triangulated_grid(10, 10, 1, 1, Point3d) == triangulated_grid(10, 10; nx=10, dy=1, point_type = Point3d)
 
-@test_throws AssertionError triangulated_grid(-10, -10, nx, ny)
-@test_throws AssertionError triangulated_grid(10, 10, -nx, -ny)
+nx = 15; ny = 20
+@test ntriangles(triangulated_grid(10, 10; nx = nx, ny = ny)) == 2*nx*ny
+@test ntriangles(triangulated_grid(1, 5; nx = nx, ny = ny)) == 2*nx*ny
+
+@test_throws AssertionError triangulated_grid(-10, -10; nx = nx, ny = ny)
+@test_throws AssertionError triangulated_grid(10, 10; nx = -nx, ny = -ny)
+@test_throws AssertionError triangulated_grid(10, 10; dx = -1, dy = -1)
 
 # Tests for the SphericalMeshes
 ρ = 6371+90


### PR DESCRIPTION
This is a small PR to add a new method for `triangulated_grid` to more finely control the size of the mesh in terms of number of triangles.