### PR TITLE
Perform Galerkin optimization ; Clean type inference ; Improve orientation code

### DIFF
--- a/ext/CombinatorialSpacesCUDAExt.jl
+++ b/ext/CombinatorialSpacesCUDAExt.jl
@@ -13,85 +13,85 @@ import CombinatorialSpaces: cache_wedge,
 # Wedge Product
 #--------------
 
-function cache_wedge(::Type{Tuple{m,n}}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p}, ::Type{Val{:CUDA}}, arr_cons=CuArray, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p}, ::Val{:CUDA}, arr_cons=CuArray, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
-function cache_wedge(::Type{Tuple{m,n}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, ::Type{Val{:CUDA}}, arr_cons=CuArray, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, ::Val{:CUDA}, arr_cons=CuArray, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
 
 # Boundary and Co-boundary
 #-------------------------
 
-"""    dec_boundary(n::Int, sd::HasDeltaSet, ::Type{Val{:CUDA}})
+"""    dec_boundary(n::Int, sd::HasDeltaSet, ::Val{:CUDA})
 
 Compute a boundary matrix as a sparse CUDA matrix.
 """
-dec_boundary(n::Int, sd::HasDeltaSet, ::Type{Val{:CUDA}}) =
+dec_boundary(n::Int, sd::HasDeltaSet, ::Val{:CUDA}) =
   CuSparseMatrixCSC(dec_boundary(n, sd))
 
-dec_boundary(n::Int, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p, ::Type{Val{:CUDA}}) where float_type =
+dec_boundary(n::Int, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p, ::Val{:CUDA}) where float_type =
   CuSparseMatrixCSC{float_type}(dec_boundary(n, sd))
-dec_boundary(n::Int, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p, ::Type{Val{:CUDA}}) where float_type =
+dec_boundary(n::Int, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p, ::Val{:CUDA}) where float_type =
   CuSparseMatrixCSC{float_type}(dec_boundary(n, sd))
 
-"""    dec_dual_derivative(n::Int, sd::EmbeddedDeltaDualComplex1D, ::Type{Val{:CUDA}})
+"""    dec_dual_derivative(n::Int, sd::EmbeddedDeltaDualComplex1D, ::Val{:CUDA})
 
 Compute a dual derivative matrix as a sparse CUDA matrix.
 """
-dec_dual_derivative(n::Int, sd::HasDeltaSet, ::Type{Val{:CUDA}}) =
+dec_dual_derivative(n::Int, sd::HasDeltaSet, ::Val{:CUDA}) =
   CuSparseMatrixCSC(dec_dual_derivative(n, sd))
 
-dec_dual_derivative(n::Int, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p, ::Type{Val{:CUDA}}) where float_type =
+dec_dual_derivative(n::Int, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p, ::Val{:CUDA}) where float_type =
   CuSparseMatrixCSC{float_type}(dec_dual_derivative(n, sd))
-dec_dual_derivative(n::Int, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p, ::Type{Val{:CUDA}}) where float_type =
+dec_dual_derivative(n::Int, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p, ::Val{:CUDA}) where float_type =
   CuSparseMatrixCSC{float_type}(dec_dual_derivative(n, sd))
 
 
-"""    dec_differential(n::Int, sd::HasDeltaSet, ::Type{Val{:CUDA}})
+"""    dec_differential(n::Int, sd::HasDeltaSet, ::Val{:CUDA})
 
 Compute an exterior derivative matrix as a sparse CUDA matrix.
 """
-dec_differential(n::Int, sd::HasDeltaSet, ::Type{Val{:CUDA}}) =
+dec_differential(n::Int, sd::HasDeltaSet, ::Val{:CUDA}) =
   CuSparseMatrixCSC(dec_differential(n, sd))
 
-dec_differential(n::Int, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p, ::Type{Val{:CUDA}}) where float_type =
+dec_differential(n::Int, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p, ::Val{:CUDA}) where float_type =
   CuSparseMatrixCSC{float_type}(dec_differential(n, sd))
-dec_differential(n::Int, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p, ::Type{Val{:CUDA}}) where float_type =
+dec_differential(n::Int, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p, ::Val{:CUDA}) where float_type =
   CuSparseMatrixCSC{float_type}(dec_differential(n, sd))
 
 # Hodge Star
 #-----------
 
-"""    dec_hodge_star(n::Int, sd::HasDeltaSet, h::DiscreteHodge, ::Type{Val{:CUDA}})
+"""    dec_hodge_star(n::Int, sd::HasDeltaSet, h::DiscreteHodge, ::Val{:CUDA})
 
 Compute a Hodge star as a diagonal or generic sparse CUDA matrix.
 """
-dec_hodge_star(n::Int, sd::HasDeltaSet, h::DiscreteHodge, ::Type{Val{:CUDA}}) = 
-  dec_hodge_star(Val{n}, sd, h, Val{:CUDA})
+dec_hodge_star(n::Int, sd::HasDeltaSet, h::DiscreteHodge, ::Val{:CUDA}) = 
+  dec_hodge_star(Val(n), sd, h, Val(:CUDA))
 
-dec_hodge_star(::Type{Val{n}}, sd::HasDeltaSet, h::DiscreteHodge, ::Type{Val{:CUDA}}) where n =
-  CuArray(dec_hodge_star(Val{n}, sd, h))
+dec_hodge_star(::Val{n}, sd::HasDeltaSet, h::DiscreteHodge, ::Val{:CUDA}) where n =
+  CuArray(dec_hodge_star(Val(n), sd, h))
 
-dec_hodge_star(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D, h::GeometricHodge, ::Type{Val{:CUDA}}) =
-  CuSparseMatrixCSC(dec_hodge_star(Val{1}, sd, h))
+dec_hodge_star(::Val{1}, sd::EmbeddedDeltaDualComplex2D, h::GeometricHodge, ::Val{:CUDA}) =
+  CuSparseMatrixCSC(dec_hodge_star(Val(1), sd, h))
 
-"""    dec_inv_hodge_star(n::Int, sd::HasDeltaSet, h::DiscreteHodge, ::Type{Val{:CUDA}})
+"""    dec_inv_hodge_star(n::Int, sd::HasDeltaSet, h::DiscreteHodge, ::Val{:CUDA})
 
 Compute an inverse Hodge star matrix as a diagonal CUDA matrix.
 """
-dec_inv_hodge_star(n::Int, sd::HasDeltaSet, h::DiscreteHodge, ::Type{Val{:CUDA}}) =
-  dec_inv_hodge_star(Val{n}, sd, h, Val{:CUDA})
+dec_inv_hodge_star(n::Int, sd::HasDeltaSet, h::DiscreteHodge, ::Val{:CUDA}) =
+  dec_inv_hodge_star(Val(n), sd, h, Val(:CUDA))
 
-dec_inv_hodge_star(::Type{Val{n}}, sd::HasDeltaSet, h::DiscreteHodge, ::Type{Val{:CUDA}}) where n =
-  CuArray(dec_inv_hodge_star(Val{n}, sd, h))
+dec_inv_hodge_star(::Val{n}, sd::HasDeltaSet, h::DiscreteHodge, ::Val{:CUDA}) where n =
+  CuArray(dec_inv_hodge_star(Val(n), sd, h))
 
-"""    function dec_inv_hodge_star(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge, ::Type{Val{:CUDA}})
+"""    function dec_inv_hodge_star(::Val{1}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge, ::Val{:CUDA})
 
 Return a function that computes the inverse geometric Hodge star of a primal 1-form via a GMRES solver.
 """
-function dec_inv_hodge_star(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge, ::Type{Val{:CUDA}})
-  hdg = -1 * dec_hodge_star(1, sd, GeometricHodge(), Val{:CUDA})
+function dec_inv_hodge_star(::Val{1}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge, ::Val{:CUDA})
+  hdg = -1 * dec_hodge_star(1, sd, GeometricHodge(), Val(:CUDA))
   x -> Krylov.gmres(hdg, x, atol = 1e-14)[1]
 end
 

--- a/src/ArrayUtils.jl
+++ b/src/ArrayUtils.jl
@@ -185,7 +185,7 @@ end
 function parse_struct_signature(expr)
   if expr isa Expr
     expr.head == :curly || error("Invalid struct expression: $expr")
-    (expr.args[1]::Symbol, collect(Symbol, expr.args[2:end]))
+    (expr.args[1]::Symbol, Base.collect(Symbol, expr.args[2:end]))
   else
     (expr::Symbol, Symbol[])
   end

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -526,14 +526,17 @@ complex. The elementary dual edges are oriented following (Hirani, 2003, Example
 relative to the primal triangles they subdivide.
 """
 function make_dual_simplices_2d!(s::HasDeltaSet2D, ::Simplex{n}) where n
+  # Fetch faces.
+  ∂2 = (∂(2,0,s), ∂(2,1,s), ∂(2,2,s))
   # Make dual vertices and edges.
   D_edges01 = make_dual_simplices_1d!(s)
   s[:tri_center] = tri_centers = add_parts!(s, :DualV, ntriangles(s))
   D_edges12 = map((0,1,2)) do e
     add_parts!(s, :DualE, ntriangles(s);
-               D_∂v0=tri_centers, D_∂v1=edge_center(s, ∂(2,e,s)))
+               D_∂v0=tri_centers, D_∂v1=edge_center(s, ∂2[e+1]))
   end
-  D_edges02 = map(triangle_vertices(s)) do vs
+  tri_verts = SVector(s[∂2[2], :∂v1], s[∂2[3], :∂v0], s[∂2[2], :∂v0])
+  D_edges02 = map(tri_verts) do vs
     add_parts!(s, :DualE, ntriangles(s);
                D_∂v0=tri_centers, D_∂v1=vertex_center(s, vs))
   end
@@ -544,35 +547,44 @@ function make_dual_simplices_2d!(s::HasDeltaSet2D, ::Simplex{n}) where n
   D_triangles = map(D_triangle_schemas) do (v,e,ev)
     add_parts!(s, :DualTri, ntriangles(s);
                D_∂e0=D_edges12[e+1], D_∂e1=D_edges02[v+1],
-               D_∂e2=view(D_edges01[ev+1], ∂(2,e,s)))
+               D_∂e2=view(D_edges01[ev+1], ∂2[e+1]))
   end
 
   if has_subpart(s, :tri_orientation)
+    tri_orient_buf = s[:tri_orientation]
     # If orientations are not set, then set them here.
-    if any(isnothing, s[:tri_orientation])
+    if any(isnothing, tri_orient_buf)
       # 2-simplices only need to be orientable if the delta set is 2D.
       # (The 2-simplices in a 3D delta set need not represent a valid 2-Manifold.)
       if n == 2
         orient!(s, Val(2)) || error("The 2-simplices of the given 2D delta set are non-orientable.")
       else
-        s[findall(isnothing, s[:tri_orientation]), :tri_orientation] = zero(attrtype_type(s, :Orientation))
+        orient_zero = zero(attrtype_type(s, :Orientation))
+        @inbounds for i in eachindex(tri_orient_buf)
+          if isnothing(tri_orient_buf[i])
+            s[i, :tri_orientation] = orient_zero
+          end
+        end
       end
+      tri_orient_buf = s[:tri_orientation]
     end
     # Orient elementary dual triangles.
-    tri_orient = s[:tri_orientation]
-    rev_tri_orient = negate.(tri_orient)
+    rev_tri_orient = negate.(tri_orient_buf)
     for (i, D_tris) in enumerate(D_triangles)
-      s[D_tris, :D_tri_orientation] = isodd(i) ? rev_tri_orient : tri_orient
+      s[D_tris, :D_tri_orientation] = isodd(i) ? rev_tri_orient : tri_orient_buf
     end
 
     # Orient elementary dual edges.
     for e in (0,1,2)
       s[D_edges12[e+1], :D_edge_orientation] = relative_sign.(
-        s[∂(2,e,s), :edge_orientation],
-        isodd(e) ? rev_tri_orient : tri_orient)
+        s[∂2[e+1], :edge_orientation],
+        isodd(e) ? rev_tri_orient : tri_orient_buf)
     end
     # Remaining dual edges are oriented arbitrarily.
-    s[lazy(vcat, D_edges02...), :D_edge_orientation] = one(attrtype_type(s, :Orientation))
+    orient_one = one(attrtype_type(s, :Orientation))
+    for D_edges in D_edges02
+        s[D_edges, :D_edge_orientation] = orient_one
+    end
   end
 
   D_triangles

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -893,7 +893,7 @@ end
 # XXX: This reference implementation is kept for pedagogical purposes;
 # it is faster to vectorize coefficient generation.
 # Wedge product of two primal 1-forms, as in Hirani 2003, Example 7.1.2.
-function ∧(::Tuple{1,1}, s::HasDeltaSet2D, α, β, x::Int)
+function ∧(::Val{1}, ::Val{1}, s::HasDeltaSet2D, α, β, x::Int)
   dual_vs = vertex_center(s, triangle_vertices(s, x))
   dual_es = sort(SVector{6}(incident(s, triangle_center(s, x), :D_∂v0)),
                  by=e -> s[e,:D_∂v1] .== dual_vs, rev=true)[1:3]
@@ -1309,7 +1309,7 @@ end
 # XXX: This reference implementation is for pedagogical purposes;
 # it is faster to vectorize coefficient generation.
 # Wedge product of a primal 2-form with a primal 1-form.
-function ∧(::Type{Tuple{2,1}}, s::HasDeltaSet3D, α, β, x::Int)
+function ∧(::Val{2}, ::Val{1}, s::HasDeltaSet3D, α, β, x::Int)
   d_tets = subsimplices(3, s, x)
   d_volume(tets) = sum(s[tets, :dual_vol])
 
@@ -1352,8 +1352,8 @@ function ∧(::Type{Tuple{2,1}}, s::HasDeltaSet3D, α, β, x::Int)
   form / 3
 end
 
-∧(::Type{Tuple{1,2}}, s::HasDeltaSet3D, α, β, x::Int) =
-  ∧(Tuple{2,1}, s, β, α, x)
+∧(::Val{1}, ::Val{2}, s::HasDeltaSet3D, α, β, x::Int) =
+  ∧(Val(2), Val(1), s, β, α, x)
 
 # General operators
 ###################
@@ -2024,19 +2024,21 @@ requires the dual complex. Note that we diverge from Hirani in that his
 formulation explicitly divides by (k+1)!. We do not do so in this computation.
 """
 ∧(s::HasDeltaSet, α::SimplexForm{k}, β::SimplexForm{l}) where {k,l} =
-  SimplexForm{k+l}(∧(Tuple{k,l}, s, α.data, β.data))
-@inline ∧(k::Int, l::Int, s::HasDeltaSet, args...) = ∧(Tuple{k,l}, s, args...)
+  SimplexForm{k+l}(∧(Val(k), Val(l), s, α.data, β.data))
+@inline ∧(k::Int, l::Int, s::HasDeltaSet, args...) =
+  ∧(Val(k), Val(l), s, args...)
 
-function ∧(::Type{Tuple{k,l}}, s::HasDeltaSet, α, β) where {k,l}
+function ∧(::Val{k}, ::Val{l}, s::HasDeltaSet, α, β) where {k,l}
   map(simplices(k+l, s)) do x
-    ∧(Tuple{k,l}, s, α, β, x)
+    ∧(Val(k), Val(l), s, α, β, x)
   end
 end
 
-∧(::Type{Tuple{0,0}}, s::HasDeltaSet, f, g, x::Int) = f[x]*g[x]
-∧(::Type{Tuple{k,0}}, s::HasDeltaSet, α, g, x::Int) where k =
+∧(::Val{0}, ::Val{0}, s::HasDeltaSet, f, g, x::Int) =
+  f[x]*g[x]
+∧(::Val{k}, ::Val{0}, s::HasDeltaSet, α, g, x::Int) where k =
   wedge_product_zero(Val(k), s, g, α, x)
-∧(::Type{Tuple{0,k}}, s::HasDeltaSet, f, β, x::Int) where k =
+∧(::Val{0}, ::Val{k}, s::HasDeltaSet, f, β, x::Int) where k =
   wedge_product_zero(Val(k), s, f, β, x)
 
 """ Wedge product of a 0-form and a ``k``-form.

--- a/src/DiscreteExteriorCalculus.jl
+++ b/src/DiscreteExteriorCalculus.jl
@@ -180,14 +180,14 @@ vertex_center(s::HasDeltaSet, args...) = s[args..., :vertex_center]
 """
 edge_center(s::HasDeltaSet1D, args...) = s[args..., :edge_center]
 
-subsimplices(::Type{Val{1}}, s::HasDeltaSet1D, e::Int) =
+subsimplices(::Val{1}, s::HasDeltaSet1D, e::Int) =
   SVector{2}(incident(s, edge_center(s, e), :D_∂v0))
 
-primal_vertex(::Type{Val{1}}, s::HasDeltaSet1D, e...) = s[e..., :D_∂v1]
+primal_vertex(::Val{1}, s::HasDeltaSet1D, e...) = s[e..., :D_∂v1]
 
-elementary_duals(::Type{Val{0}}, s::AbstractDeltaDualComplex1D, v::Int) =
+elementary_duals(::Val{0}, s::AbstractDeltaDualComplex1D, v::Int) =
   incident(s, vertex_center(s,v), :D_∂v1)
-elementary_duals(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, e::Int) =
+elementary_duals(::Val{1}, s::AbstractDeltaDualComplex1D, e::Int) =
   SVector(edge_center(s,e))
 
 """ Boundary dual vertices of a dual edge.
@@ -224,13 +224,13 @@ end
 @acset_type OrientedDeltaDualComplex1D(SchOrientedDeltaDualComplex1D,
   index=[:∂v0,:∂v1,:D_∂v0,:D_∂v1]) <: AbstractDeltaDualComplex1D
 
-dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, x::Int) =
+dual_boundary_nz(::Val{1}, s::AbstractDeltaDualComplex1D, x::Int) =
   # Boundary vertices of dual 1-cell ↔
   # Dual vertices for cofaces of (i.e. edges incident to) primal vertex.
-  d_nz(Val{0}, s, x)
+  d_nz(Val(0), s, x)
 
-dual_derivative_nz(::Type{Val{0}}, s::AbstractDeltaDualComplex1D, x::Int) =
-  negatenz(∂_nz(Val{1}, s, x))
+dual_derivative_nz(::Val{0}, s::AbstractDeltaDualComplex1D, x::Int) =
+  negatenz(∂_nz(Val(1), s, x))
 
 negatenz((I, V)) = (I, negate.(V))
 
@@ -269,7 +269,7 @@ function copy_primal_1D!(t::HasDeltaSet1D, s::HasDeltaSet1D)
   end
 end
 
-make_dual_simplices_1d!(s::AbstractDeltaDualComplex1D) = make_dual_simplices_1d!(s, E)
+make_dual_simplices_1d!(s::AbstractDeltaDualComplex1D) = make_dual_simplices_1d!(s, E(0))
 
 """ Make dual vertices and edges for dual complex of dimension ≧ 1.
 
@@ -281,7 +281,7 @@ If the primal complex is oriented, an orientation is induced on the dual
 complex. The dual edges are oriented relative to the primal edges they subdivide
 (Hirani 2003, PhD thesis, Ch. 2, last sentence of Remark 2.5.1).
 """
-function make_dual_simplices_1d!(s::HasDeltaSet1D, ::Type{Simplex{n}}) where n
+function make_dual_simplices_1d!(s::HasDeltaSet1D, ::Simplex{n}) where n
   # Make dual vertices and edges.
   s[:vertex_center] = vcenters = add_parts!(s, :DualV, nv(s))
   s[:edge_center] = ecenters = add_parts!(s, :DualV, ne(s))
@@ -297,7 +297,7 @@ function make_dual_simplices_1d!(s::HasDeltaSet1D, ::Type{Simplex{n}}) where n
       # 1-simplices only need to be orientable if the delta set is 1D.
       # (The 1-simplices in a 2D delta set need not represent a valid 1-Manifold.)
       if n == 1
-        orient!(s, E) || error("The 1-simplices of the given 1D delta set are non-orientable.")
+        orient!(s, Val(1)) || error("The 1-simplices of the given 1D delta set are non-orientable.")
       else
         s[findall(isnothing, s[:edge_orientation]), :edge_orientation] = zero(attrtype_type(s, :Orientation))
       end
@@ -336,22 +336,22 @@ dual_point(s::HasDeltaSet, args...) = s[args..., :dual_point]
 
 struct PrecomputedVol end
 
-volume(::Type{Val{n}}, s::EmbeddedDeltaDualComplex1D, x) where n =
-  volume(Val{n}, s, x, PrecomputedVol())
-dual_volume(::Type{Val{n}}, s::EmbeddedDeltaDualComplex1D, x) where n =
-  dual_volume(Val{n}, s, x, PrecomputedVol())
+volume(::Val{n}, s::EmbeddedDeltaDualComplex1D, x) where n =
+  volume(Val(n), s, x, PrecomputedVol())
+dual_volume(::Val{n}, s::EmbeddedDeltaDualComplex1D, x) where n =
+  dual_volume(Val(n), s, x, PrecomputedVol())
 
-volume(::Type{Val{1}}, s::HasDeltaSet1D, e, ::PrecomputedVol) = s[e, :length]
-dual_volume(::Type{Val{1}}, s::HasDeltaSet1D, e, ::PrecomputedVol) =
+volume(::Val{1}, s::HasDeltaSet1D, e, ::PrecomputedVol) = s[e, :length]
+dual_volume(::Val{1}, s::HasDeltaSet1D, e, ::PrecomputedVol) =
   s[e, :dual_length]
 
-dual_volume(::Type{Val{1}}, s::HasDeltaSet1D, e::Int, ::CayleyMengerDet) =
+dual_volume(::Val{1}, s::HasDeltaSet1D, e::Int, ::CayleyMengerDet) =
   volume(dual_point(s, SVector(s[e,:D_∂v0], s[e,:D_∂v1])))
 
-hodge_diag(::Type{Val{0}}, s::AbstractDeltaDualComplex1D, v::Int) =
-  sum(dual_volume(Val{1}, s, elementary_duals(Val{0},s,v)))
-hodge_diag(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, e::Int) =
-  1 / volume(Val{1},s,e)
+hodge_diag(::Val{0}, s::AbstractDeltaDualComplex1D, v::Int) =
+  sum(dual_volume(Val(1), s, elementary_duals(Val(0), s, v)))
+hodge_diag(::Val{1}, s::AbstractDeltaDualComplex1D, e::Int) =
+  1 / volume(Val(1), s, e)
 
 """ Compute geometric subdivision for embedded dual complex.
 
@@ -442,17 +442,17 @@ end
 """
 triangle_center(s::HasDeltaSet2D, args...) = s[args..., :tri_center]
 
-subsimplices(::Type{Val{2}}, s::HasDeltaSet2D, t::Int) =
+subsimplices(::Val{2}, s::HasDeltaSet2D, t::Int) =
   SVector{6}(incident(s, triangle_center(s,t), @SVector [:D_∂e1, :D_∂v0]))
 
-primal_vertex(::Type{Val{2}}, s::HasDeltaSet2D, t...) =
-  primal_vertex(Val{1}, s, s[t..., :D_∂e2])
+primal_vertex(::Val{2}, s::HasDeltaSet2D, t...) =
+  primal_vertex(Val(1), s, s[t..., :D_∂e2])
 
-elementary_duals(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, v::Int) =
+elementary_duals(::Val{0}, s::AbstractDeltaDualComplex2D, v::Int) =
   incident(s, vertex_center(s,v), @SVector [:D_∂e1, :D_∂v1])
-elementary_duals(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, e::Int) =
+elementary_duals(::Val{1}, s::AbstractDeltaDualComplex2D, e::Int) =
   incident(s, edge_center(s,e), :D_∂v1)
-elementary_duals(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, t::Int) =
+elementary_duals(::Val{2}, s::AbstractDeltaDualComplex2D, t::Int) =
   SVector(triangle_center(s,t))
 
 # 2D oriented dual complex
@@ -471,19 +471,19 @@ end
 @acset_type OrientedDeltaDualComplex2D(SchOrientedDeltaDualComplex2D,
   index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:D_∂v0,:D_∂v1,:D_∂e0,:D_∂e1,:D_∂e2]) <: AbstractDeltaDualComplex2D
 
-dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, x::Int) =
+dual_boundary_nz(::Val{1}, s::AbstractDeltaDualComplex2D, x::Int) =
   # Boundary vertices of dual 1-cell ↔
   # Dual vertices for cofaces of (triangles incident to) primal edge.
-  negatenz(d_nz(Val{1}, s, x))
-dual_boundary_nz(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, x::Int) =
+  negatenz(d_nz(Val(1), s, x))
+dual_boundary_nz(::Val{2}, s::AbstractDeltaDualComplex2D, x::Int) =
   # Boundary edges of dual 2-cell ↔
   # Dual edges for cofaces of (edges incident to) primal vertex.
-  d_nz(Val{0}, s, x)
+  d_nz(Val(0), s, x)
 
-dual_derivative_nz(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, x::Int) =
-  ∂_nz(Val{2}, s, x)
-dual_derivative_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, x::Int) =
-  negatenz(∂_nz(Val{1}, s, x))
+dual_derivative_nz(::Val{0}, s::AbstractDeltaDualComplex2D, x::Int) =
+  ∂_nz(Val(2), s, x)
+dual_derivative_nz(::Val{1}, s::AbstractDeltaDualComplex2D, x::Int) =
+  negatenz(∂_nz(Val(1), s, x))
 
 """ Construct 2D dual complex from 2D delta set.
 """
@@ -514,9 +514,9 @@ function copy_primal_2D!(t::HasDeltaSet2D, s::HasDeltaSet2D)
   end
 end
 
-make_dual_simplices_1d!(s::AbstractDeltaDualComplex2D) = make_dual_simplices_1d!(s, Tri)
+make_dual_simplices_1d!(s::AbstractDeltaDualComplex2D) = make_dual_simplices_1d!(s, Tri(0))
 
-make_dual_simplices_2d!(s::AbstractDeltaDualComplex2D) = make_dual_simplices_2d!(s, Tri)
+make_dual_simplices_2d!(s::AbstractDeltaDualComplex2D) = make_dual_simplices_2d!(s, Tri(0))
 
 """ Make dual simplices for dual complex of dimension ≧ 2.
 
@@ -525,7 +525,7 @@ complex. The elementary dual edges are oriented following (Hirani, 2003, Example
 2.5.2) or (Desbrun et al, 2005, Table 1) and the dual triangles are oriented
 relative to the primal triangles they subdivide.
 """
-function make_dual_simplices_2d!(s::HasDeltaSet2D, ::Type{Simplex{n}}) where n
+function make_dual_simplices_2d!(s::HasDeltaSet2D, ::Simplex{n}) where n
   # Make dual vertices and edges.
   D_edges01 = make_dual_simplices_1d!(s)
   s[:tri_center] = tri_centers = add_parts!(s, :DualV, ntriangles(s))
@@ -553,7 +553,7 @@ function make_dual_simplices_2d!(s::HasDeltaSet2D, ::Type{Simplex{n}}) where n
       # 2-simplices only need to be orientable if the delta set is 2D.
       # (The 2-simplices in a 3D delta set need not represent a valid 2-Manifold.)
       if n == 2
-        orient!(s, Tri) || error("The 2-simplices of the given 2D delta set are non-orientable.")
+        orient!(s, Val(2)) || error("The 2-simplices of the given 2D delta set are non-orientable.")
       else
         s[findall(isnothing, s[:tri_orientation]), :tri_orientation] = zero(attrtype_type(s, :Orientation))
       end
@@ -602,28 +602,28 @@ primal/dual edges and triangles are precomputed and stored.
 @acset_type EmbeddedDeltaDualComplex2D(SchEmbeddedDeltaDualComplex2D,
   index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:D_∂v0,:D_∂v1,:D_∂e0,:D_∂e1,:D_∂e2]) <: AbstractDeltaDualComplex2D
 
-volume(::Type{Val{n}}, s::EmbeddedDeltaDualComplex2D, x) where n =
-  volume(Val{n}, s, x, PrecomputedVol())
-dual_volume(::Type{Val{n}}, s::EmbeddedDeltaDualComplex2D, x) where n =
-  dual_volume(Val{n}, s, x, PrecomputedVol())
+volume(::Val{n}, s::EmbeddedDeltaDualComplex2D, x) where n =
+  volume(Val(n), s, x, PrecomputedVol())
+dual_volume(::Val{n}, s::EmbeddedDeltaDualComplex2D, x) where n =
+  dual_volume(Val(n), s, x, PrecomputedVol())
 
-volume(::Type{Val{2}}, s::HasDeltaSet2D, t, ::PrecomputedVol) = s[t, :area]
-dual_volume(::Type{Val{2}}, s::HasDeltaSet2D, t, ::PrecomputedVol) =
+volume(::Val{2}, s::HasDeltaSet2D, t, ::PrecomputedVol) = s[t, :area]
+dual_volume(::Val{2}, s::HasDeltaSet2D, t, ::PrecomputedVol) =
   s[t, :dual_area]
 
-function dual_volume(::Type{Val{2}}, s::HasDeltaSet2D, t::Int, ::CayleyMengerDet)
+function dual_volume(::Val{2}, s::HasDeltaSet2D, t::Int, ::CayleyMengerDet)
   dual_vs = SVector(s[s[t, :D_∂e1], :D_∂v1],
                     s[s[t, :D_∂e2], :D_∂v0],
                     s[s[t, :D_∂e0], :D_∂v0])
   volume(dual_point(s, dual_vs))
 end
 
-hodge_diag(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, v::Int) =
-  sum(dual_volume(Val{2}, s, elementary_duals(Val{0},s,v)))
-hodge_diag(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, e::Int) =
-  sum(dual_volume(Val{1}, s, elementary_duals(Val{1},s,e))) / volume(Val{1},s,e)
-hodge_diag(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, t::Int) =
-  1 / volume(Val{2},s,t)
+hodge_diag(::Val{0}, s::AbstractDeltaDualComplex2D, v::Int) =
+  sum(dual_volume(Val(2), s, elementary_duals(Val(0), s, v)))
+hodge_diag(::Val{1}, s::AbstractDeltaDualComplex2D, e::Int) =
+  sum(dual_volume(Val(1), s, elementary_duals(Val(1), s, e))) / volume(Val(1), s, e)
+hodge_diag(::Val{2}, s::AbstractDeltaDualComplex2D, t::Int) =
+  1 / volume(Val(2), s, t)
 
 function ♭(s::AbstractDeltaDualComplex2D, X::AbstractVector, ::DPPFlat)
   # XXX: Creating this lookup table shouldn't be necessary. Of course, we could
@@ -881,7 +881,7 @@ end
 # XXX: This reference implementation is kept for pedagogical purposes;
 # it is faster to vectorize coefficient generation.
 # Wedge product of two primal 1-forms, as in Hirani 2003, Example 7.1.2.
-function ∧(::Type{Tuple{1,1}}, s::HasDeltaSet2D, α, β, x::Int)
+function ∧(::Tuple{1,1}, s::HasDeltaSet2D, α, β, x::Int)
   dual_vs = vertex_center(s, triangle_vertices(s, x))
   dual_es = sort(SVector{6}(incident(s, triangle_center(s, x), :D_∂v0)),
                  by=e -> s[e,:D_∂v1] .== dual_vs, rev=true)[1:3]
@@ -925,12 +925,12 @@ end
 
 function precompute_volumes_2d!(sd::HasDeltaSet2D, p::Type{point_type}) where point_type
   precompute_volumes_1d!(sd, point_type)
-  set_volumes_2d!(Val{2}, sd, p)
-  set_dual_volumes_2d!(Val{2}, sd, p)
+  set_volumes_2d!(Val(2), sd, p)
+  set_dual_volumes_2d!(Val(2), sd, p)
 end
 
 # TODO: Replace the individual accesses with vector accesses
-function set_volumes_2d!(::Type{Val{2}}, sd::HasDeltaSet2D, ::Type{point_type}) where point_type
+function set_volumes_2d!(::Val{2}, sd::HasDeltaSet2D, ::Type{point_type}) where point_type
 
   point_arr = MVector{3, point_type}(undef)
 
@@ -945,7 +945,7 @@ function set_volumes_2d!(::Type{Val{2}}, sd::HasDeltaSet2D, ::Type{point_type}) 
 end
 
 # TODO: Replace the individual accesses with vector accesses
-function set_dual_volumes_2d!(::Type{Val{2}}, sd::HasDeltaSet2D, ::Type{point_type}) where point_type
+function set_dual_volumes_2d!(::Val{2}, sd::HasDeltaSet2D, ::Type{point_type}) where point_type
 
   point_arr = MVector{3, point_type}(undef)
 
@@ -1001,19 +1001,19 @@ const AbstractDeltaDualComplex = Union{AbstractDeltaDualComplex1D, AbstractDelta
 """
 tetrahedron_center(s::HasDeltaSet3D, args...) = s[args..., :tet_center]
 
-subsimplices(::Type{Val{3}}, s::HasDeltaSet3D, tet::Int) =
+subsimplices(::Val{3}, s::HasDeltaSet3D, tet::Int) =
   SVector{24}(incident(s, tetrahedron_center(s,tet), @SVector [:D_∂t1, :D_∂e1, :D_∂v0]))
 
-primal_vertex(::Type{Val{3}}, s::HasDeltaSet3D, tet...) =
-  primal_vertex(Val{2}, s, s[tet..., :D_∂t1])
+primal_vertex(::Val{3}, s::HasDeltaSet3D, tet...) =
+  primal_vertex(Val(2), s, s[tet..., :D_∂t1])
 
-elementary_duals(::Type{Val{0}}, s::AbstractDeltaDualComplex3D, v::Int) =
+elementary_duals(::Val{0}, s::AbstractDeltaDualComplex3D, v::Int) =
   incident(s, vertex_center(s,v), @SVector [:D_∂t1, :D_∂e1, :D_∂v1])
-elementary_duals(::Type{Val{1}}, s::AbstractDeltaDualComplex3D, e::Int) =
+elementary_duals(::Val{1}, s::AbstractDeltaDualComplex3D, e::Int) =
   incident(s, edge_center(s,e), @SVector [:D_∂e1, :D_∂v1])
-elementary_duals(::Type{Val{2}}, s::AbstractDeltaDualComplex3D, t::Int) =
+elementary_duals(::Val{2}, s::AbstractDeltaDualComplex3D, t::Int) =
   incident(s, triangle_center(s,t), :D_∂v1)
-elementary_duals(::Type{Val{3}}, s::AbstractDeltaDualComplex3D, tet::Int) =
+elementary_duals(::Val{3}, s::AbstractDeltaDualComplex3D, tet::Int) =
   SVector(tetrahedron_center(s,tet))
 
 """ Boundary dual vertices of a dual tetrahedron.
@@ -1045,25 +1045,25 @@ end
 @acset_type OrientedDeltaDualComplex3D(SchOrientedDeltaDualComplex3D,
   index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:D_∂v0,:D_∂v1,:D_∂e0,:D_∂e1,:D_∂e2,:D_∂t0,:D_∂t1,:D_∂t2,:D_∂t3]) <: AbstractDeltaDualComplex3D
 
-dual_boundary_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex3D, x::Int) =
+dual_boundary_nz(::Val{1}, s::AbstractDeltaDualComplex3D, x::Int) =
   # Boundary vertices of dual 1-cell ↔
   # Dual vertices for cofaces of (tetrahedra incident to) primal triangle.
-  d_nz(Val{2}, s, x)
-dual_boundary_nz(::Type{Val{2}}, s::AbstractDeltaDualComplex3D, x::Int) =
+  d_nz(Val(2), s, x)
+dual_boundary_nz(::Val{2}, s::AbstractDeltaDualComplex3D, x::Int) =
   # Boundary edges of dual 2-cell ↔
   # Dual edges for cofaces of (i.e. triangles incident to) primal edge.
-  negatenz(d_nz(Val{1}, s, x))
-dual_boundary_nz(::Type{Val{3}}, s::AbstractDeltaDualComplex3D, x::Int) =
+  negatenz(d_nz(Val(1), s, x))
+dual_boundary_nz(::Val{3}, s::AbstractDeltaDualComplex3D, x::Int) =
   # Boundary triangles of dual 3-cell ↔
   # Dual triangles for cofaces of (i.e. edges incident to) primal vertex.
-  d_nz(Val{0}, s, x)
+  d_nz(Val(0), s, x)
 
-dual_derivative_nz(::Type{Val{0}}, s::AbstractDeltaDualComplex3D, x::Int) =
-  negatenz(∂_nz(Val{3}, s, x))
-dual_derivative_nz(::Type{Val{1}}, s::AbstractDeltaDualComplex3D, x::Int) =
-  ∂_nz(Val{2}, s, x)
-dual_derivative_nz(::Type{Val{2}}, s::AbstractDeltaDualComplex3D, x::Int) =
-  negatenz(∂_nz(Val{1}, s, x))
+dual_derivative_nz(::Val{0}, s::AbstractDeltaDualComplex3D, x::Int) =
+  negatenz(∂_nz(Val(3), s, x))
+dual_derivative_nz(::Val{1}, s::AbstractDeltaDualComplex3D, x::Int) =
+  ∂_nz(Val(2), s, x)
+dual_derivative_nz(::Val{2}, s::AbstractDeltaDualComplex3D, x::Int) =
+  negatenz(∂_nz(Val(1), s, x))
 
 """ Construct 3D dual complex from 3D delta set.
 """
@@ -1074,11 +1074,11 @@ function (::Type{S})(t::AbstractDeltaSet3D) where S <: AbstractDeltaDualComplex3
   return s
 end
 
-make_dual_simplices_1d!(s::AbstractDeltaDualComplex3D) = make_dual_simplices_1d!(s, Tet)
+make_dual_simplices_1d!(s::AbstractDeltaDualComplex3D) = make_dual_simplices_1d!(s, Tet(0))
 
-make_dual_simplices_2d!(s::AbstractDeltaDualComplex3D) = make_dual_simplices_2d!(s, Tet)
+make_dual_simplices_2d!(s::AbstractDeltaDualComplex3D) = make_dual_simplices_2d!(s, Tet(0))
 
-make_dual_simplices_3d!(s::AbstractDeltaDualComplex3D) = make_dual_simplices_3d!(s, Tet)
+make_dual_simplices_3d!(s::AbstractDeltaDualComplex3D) = make_dual_simplices_3d!(s, Tet(0))
 
 # Note: these accessors are isomorphic to those for their primal counterparts.
 # These can be eliminated by the DualComplex schema refactor.
@@ -1138,7 +1138,7 @@ end
 If the primal complex is oriented, an orientation is induced on the dual
 complex.
 """
-function make_dual_simplices_3d!(s::HasDeltaSet3D, ::Type{Simplex{n}}) where n
+function make_dual_simplices_3d!(s::HasDeltaSet3D, ::Simplex{n}) where n
   make_dual_simplices_2d!(s)
   s[:tet_center] = add_parts!(s, :DualV, ntetrahedra(s))
   for tet in tetrahedra(s)
@@ -1173,7 +1173,7 @@ function make_dual_simplices_3d!(s::HasDeltaSet3D, ::Type{Simplex{n}}) where n
     if any(isnothing, s[:tet_orientation])
       # Primal 3-simplices only need to be orientable if the delta set is 3D.
       if n == 3
-        orient!(s, Tet) || error("The 3-simplices of the given 3D delta set are non-orientable.")
+        orient!(s, Val(3)) || error("The 3-simplices of the given 3D delta set are non-orientable.")
       else
         # This line would be called if the complex is 4D.
         s[findall(isnothing, s[:tet_orientation]), :tet_orientation] = zero(attrtype_type(s, :Orientation))
@@ -1237,16 +1237,16 @@ end
 @acset_type EmbeddedDeltaDualComplex3D(SchEmbeddedDeltaDualComplex3D,
   index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:D_∂v0,:D_∂v1,:D_∂e0,:D_∂e1,:D_∂e2,:D_∂t0,:D_∂t1,:D_∂t2,:D_∂t3]) <: AbstractDeltaDualComplex3D
 
-volume(::Type{Val{n}}, s::EmbeddedDeltaDualComplex3D, x) where n =
-  volume(Val{n}, s, x, PrecomputedVol())
-dual_volume(::Type{Val{n}}, s::EmbeddedDeltaDualComplex3D, x) where n =
-  dual_volume(Val{n}, s, x, PrecomputedVol())
+volume(::Val{n}, s::EmbeddedDeltaDualComplex3D, x) where n =
+  volume(Val(n), s, x, PrecomputedVol())
+dual_volume(::Val{n}, s::EmbeddedDeltaDualComplex3D, x) where n =
+  dual_volume(Val(n), s, x, PrecomputedVol())
 
-volume(::Type{Val{3}}, s::HasDeltaSet3D, tet, ::PrecomputedVol) = s[tet, :vol]
-dual_volume(::Type{Val{3}}, s::HasDeltaSet3D, tet, ::PrecomputedVol) =
+volume(::Val{3}, s::HasDeltaSet3D, tet, ::PrecomputedVol) = s[tet, :vol]
+dual_volume(::Val{3}, s::HasDeltaSet3D, tet, ::PrecomputedVol) =
   s[tet, :dual_vol]
 
-function dual_volume(::Type{Val{3}}, s::HasDeltaSet3D, tet::Int, ::CayleyMengerDet)
+function dual_volume(::Val{3}, s::HasDeltaSet3D, tet::Int, ::CayleyMengerDet)
   dual_vs = SVector(s[s[s[tet, :D_∂t2], :D_∂e2], :D_∂v1],
                     s[s[s[tet, :D_∂t2], :D_∂e2], :D_∂v0],
                     s[s[s[tet, :D_∂t0], :D_∂e0], :D_∂v1],
@@ -1254,15 +1254,15 @@ function dual_volume(::Type{Val{3}}, s::HasDeltaSet3D, tet::Int, ::CayleyMengerD
   volume(dual_point(s, dual_vs))
 end
 
-hodge_diag(::Type{Val{0}}, s::AbstractDeltaDualComplex3D, v::Int) =
-  sum(dual_volume(Val{3}, s, elementary_duals(Val{0},s,v)))
+hodge_diag(::Val{0}, s::AbstractDeltaDualComplex3D, v::Int) =
+  sum(dual_volume(Val(3), s, elementary_duals(Val(0),s,v)))
 # 1 / |⋆σᵖ| <*α,⋆σᵖ> := 1 / |σᵖ| <α,σᵖ>
-hodge_diag(::Type{Val{1}}, s::AbstractDeltaDualComplex3D, e::Int) =
-  sum(dual_volume(Val{2}, s, elementary_duals(Val{1},s,e))) / volume(Val{1},s,e)
-hodge_diag(::Type{Val{2}}, s::AbstractDeltaDualComplex3D, t::Int) =
-  sum(dual_volume(Val{1}, s, elementary_duals(Val{2},s,t))) / volume(Val{2},s,t)
-hodge_diag(::Type{Val{3}}, s::AbstractDeltaDualComplex3D, tet::Int) =
-  1 / volume(Val{3},s,tet)
+hodge_diag(::Val{1}, s::AbstractDeltaDualComplex3D, e::Int) =
+  sum(dual_volume(Val(2), s, elementary_duals(Val(1),s,e))) / volume(Val(1),s,e)
+hodge_diag(::Val{2}, s::AbstractDeltaDualComplex3D, t::Int) =
+  sum(dual_volume(Val(1), s, elementary_duals(Val(2),s,t))) / volume(Val(2),s,t)
+hodge_diag(::Val{3}, s::AbstractDeltaDualComplex3D, tet::Int) =
+  1 / volume(Val(3),s,tet)
 
 # TODO: Instead of rewriting ♭_mat by replacing tris with tets, use multiple dispatch.
 #function ♭_mat(s::AbstractDeltaDualComplex3D)
@@ -1431,9 +1431,9 @@ ndims(s::AbstractDeltaDualComplex2D) = 2
 ndims(s::AbstractDeltaDualComplex3D) = 3
 
 volume(s::HasDeltaSet, x::DualSimplex{n}, args...) where n =
-  dual_volume(Val{n}, s, x.data, args...)
+  dual_volume(Val(n), s, x.data, args...)
 @inline dual_volume(n::Int, s::HasDeltaSet, args...) =
-  dual_volume(Val{n}, s, args...)
+  dual_volume(Val(n), s, args...)
 
 """ List of dual simplices comprising the subdivision of a primal simplex.
 
@@ -1445,16 +1445,16 @@ The returned list is ordered such that subsimplices with the same primal vertex
 appear consecutively.
 """
 subsimplices(s::HasDeltaSet, x::Simplex{n}) where n =
-  DualSimplex{n}(subsimplices(Val{n}, s, x.data))
+  DualSimplex{n}(subsimplices(Val(n), s, x.data))
 @inline subsimplices(n::Int, s::HasDeltaSet, args...) =
-  subsimplices(Val{n}, s, args...)
+  subsimplices(Val(n), s, args...)
 
 """ Primal vertex associated with a dual simplex.
 """
 primal_vertex(s::HasDeltaSet, x::DualSimplex{n}) where n =
-  V(primal_vertex(Val{n}, s, x.data))
+  V(primal_vertex(Val(n), s, x.data))
 @inline primal_vertex(n::Int, s::HasDeltaSet, args...) =
-  primal_vertex(Val{n}, s, args...)
+  primal_vertex(Val(n), s, args...)
 
 """ List of elementary dual simplices corresponding to primal simplex.
 
@@ -1479,23 +1479,23 @@ In 3D dual complexes, the elementary duals of...
 - primal tetrahedra are (single) dual vertices
 """
 elementary_duals(s::HasDeltaSet, x::Simplex{n}) where n =
-  DualSimplex{ndims(s)-n}(elementary_duals(Val{n}, s, x.data))
+  DualSimplex{ndims(s)-n}(elementary_duals(Val(n), s, x.data))
 @inline elementary_duals(n::Int, s::HasDeltaSet, args...) =
-  elementary_duals(Val{n}, s, args...)
+  elementary_duals(Val(n), s, args...)
 
 """ Boundary of chain of dual cells.
 
 Transpose of [`dual_derivative`](@ref).
 """
 @inline dual_boundary(n::Int, s::HasDeltaSet, args...) =
-  dual_boundary(Val{n}, s, args...)
+  dual_boundary(Val(n), s, args...)
 ∂(s::HasDeltaSet, x::DualChain{n}) where n =
-  DualChain{n-1}(dual_boundary(Val{n}, s, x.data))
+  DualChain{n-1}(dual_boundary(Val(n), s, x.data))
 
-function dual_boundary(::Type{Val{n}}, s::HasDeltaSet, args...) where n
+function dual_boundary(::Val{n}, s::HasDeltaSet, args...) where n
   operator_nz(Int, nsimplices(ndims(s)-n+1,s),
               nsimplices(ndims(s)-n,s), args...) do x
-    dual_boundary_nz(Val{n}, s, x)
+    dual_boundary_nz(Val(n), s, x)
   end
 end
 
@@ -1505,14 +1505,14 @@ Transpose of [`dual_boundary`](@ref). For more info, see (Desbrun, Kanso, Tong,
 2008: Discrete differential forms for computational modeling, §4.5).
 """
 @inline dual_derivative(n::Int, s::HasDeltaSet, args...) =
-  dual_derivative(Val{n}, s, args...)
+  dual_derivative(Val(n), s, args...)
 d(s::HasDeltaSet, x::DualForm{n}) where n =
-  DualForm{n+1}(dual_derivative(Val{n}, s, x.data))
+  DualForm{n+1}(dual_derivative(Val(n), s, x.data))
 
-function dual_derivative(::Type{Val{n}}, s::HasDeltaSet, args...) where n
+function dual_derivative(::Val{n}, s::HasDeltaSet, args...) where n
   operator_nz(Int, nsimplices(ndims(s)-n-1,s),
               nsimplices(ndims(s)-n,s), args...) do x
-    dual_derivative_nz(Val{n}, s, x)
+    dual_derivative_nz(Val(n), s, x)
   end
 end
 
@@ -1606,17 +1606,20 @@ fancy_acset_schema(d::HasDeltaSet) = Presentation(acset_schema(d))
     we use the symbol ``⋆`` for the Hodge star.
 """
 ⋆(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n =
-  DualForm{ndims(s)-n}(⋆(Val{n}, s, x.data; kw...))
-@inline ⋆(n::Int, s::HasDeltaSet, args...; kw...) = ⋆(Val{n}, s, args...; kw...)
-@inline ⋆(::Type{Val{n}}, s::HasDeltaSet;
-          hodge::DiscreteHodge=GeometricHodge()) where n = ⋆(Val{n}, s, hodge)
-@inline ⋆(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector;
-          hodge::DiscreteHodge=GeometricHodge()) where n = ⋆(Val{n}, s, form, hodge)
+  DualForm{ndims(s)-n}(⋆(Val(n), s, x.data; kw...))
+@inline ⋆(n::Int, s::HasDeltaSet, args...; kw...) =
+  ⋆(Val(n), s, args...; kw...)
+@inline ⋆(::Val{n}, s::HasDeltaSet;
+          hodge::DiscreteHodge=GeometricHodge()) where n =
+  ⋆(Val(n), s, hodge)
+@inline ⋆(::Val{n}, s::HasDeltaSet, form::AbstractVector;
+          hodge::DiscreteHodge=GeometricHodge()) where n =
+  ⋆(Val(n), s, form, hodge)
 
-⋆(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector, ::DiagonalHodge) where n =
-  applydiag(form) do x, a; a * hodge_diag(Val{n},s,x) end
-⋆(::Type{Val{n}}, s::HasDeltaSet, ::DiagonalHodge) where n =
-  Diagonal([ hodge_diag(Val{n},s,x) for x in simplices(n,s) ])
+⋆(::Val{n}, s::HasDeltaSet, form::AbstractVector, ::DiagonalHodge) where n =
+  applydiag(form) do x, a; a * hodge_diag(Val(n),s,x) end
+⋆(::Val{n}, s::HasDeltaSet, ::DiagonalHodge) where n =
+  Diagonal([ hodge_diag(Val(n),s,x) for x in simplices(n,s) ])
 
 # Note that this cross product defines the positive direction for flux to
 # always be in the positive z direction. This will likely not generalize to
@@ -1637,7 +1640,7 @@ This reproduces the diagonal hodge for a dual mesh generated under
 circumcentric subdivision and provides off-diagonal correction factors for
 meshes generated under other subdivision schemes (e.g. barycentric).
 """
-function ⋆(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
+function ⋆(::Val{1}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
 
   vals = Dict{Tuple{Int64, Int64}, Float64}()
   I = Vector{Int64}()
@@ -1662,7 +1665,7 @@ function ⋆(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
     # case that the mesh has multiple independent connected components
     rel_orient = 0.0
     for i in 1:3
-      diag_cross = sign(Val{2}, s, t) * crossdot(ev[i], dv[i]) /
+      diag_cross = sign(Val(2), s, t) * crossdot(ev[i], dv[i]) /
                       dot(ev[i], ev[i])
       if diag_cross != 0.0
         # Decide the orientation of the mesh relative to z-axis (see crossdot)
@@ -1679,7 +1682,7 @@ function ⋆(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
 
     for p ∈ ((1,2,3), (1,3,2), (2,1,3),
              (2,3,1), (3,1,2), (3,2,1))
-      val = rel_orient * sign(Val{2}, s, t) * diag_dot[p[1]] *
+      val = rel_orient * sign(Val(2), s, t) * diag_dot[p[1]] *
               dot(ev[p[1]], ev[p[3]]) / crossdot(ev[p[2]], ev[p[3]])
       if val != 0.0
         push!(I, e[p[1]])
@@ -1691,22 +1694,22 @@ function ⋆(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge)
   sparse(I,J,V)
 end
 
-⋆(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge) =
-  ⋆(Val{0}, s, DiagonalHodge())
-⋆(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge) =
-  ⋆(Val{2}, s, DiagonalHodge())
+⋆(::Val{0}, s::AbstractDeltaDualComplex2D, ::GeometricHodge) =
+  ⋆(Val(0), s, DiagonalHodge())
+⋆(::Val{2}, s::AbstractDeltaDualComplex2D, ::GeometricHodge) =
+  ⋆(Val(2), s, DiagonalHodge())
 
-⋆(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge) =
-  ⋆(Val{0}, s, form, DiagonalHodge())
-⋆(::Type{Val{1}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge) =
-  ⋆(Val{1}, s, GeometricHodge()) * form
-⋆(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge) =
-  ⋆(Val{2}, s, form, DiagonalHodge())
+⋆(::Val{0}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge) =
+  ⋆(Val(0), s, form, DiagonalHodge())
+⋆(::Val{1}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge) =
+  ⋆(Val(1), s, GeometricHodge()) * form
+⋆(::Val{2}, s::AbstractDeltaDualComplex2D, form::AbstractVector, ::GeometricHodge) =
+  ⋆(Val(2), s, form, DiagonalHodge())
 
-⋆(::Type{Val{n}}, s::AbstractDeltaDualComplex1D, ::GeometricHodge) where n =
-  ⋆(Val{n}, s, DiagonalHodge())
-⋆(::Type{Val{n}}, s::AbstractDeltaDualComplex1D, form::AbstractVector, ::GeometricHodge) where n =
-  ⋆(Val{n}, s, form, DiagonalHodge())
+⋆(::Val{n}, s::AbstractDeltaDualComplex1D, ::GeometricHodge) where n =
+  ⋆(Val(n), s, DiagonalHodge())
+⋆(::Val{n}, s::AbstractDeltaDualComplex1D, form::AbstractVector, ::GeometricHodge) where n =
+  ⋆(Val(n), s, form, DiagonalHodge())
 
 """ Alias for the Hodge star operator [`⋆`](@ref).
 """
@@ -1719,58 +1722,58 @@ because it carries an extra global sign, in analogy to the smooth case
 (Gillette, 2009, Notes on the DEC, Definition 2.27).
 """
 @inline inv_hodge_star(n::Int, s::HasDeltaSet, args...; kw...) =
-  inv_hodge_star(Val{n}, s, args...; kw...)
-@inline inv_hodge_star(::Type{Val{n}}, s::HasDeltaSet;
+  inv_hodge_star(Val(n), s, args...; kw...)
+@inline inv_hodge_star(::Val{n}, s::HasDeltaSet;
                        hodge::DiscreteHodge=GeometricHodge()) where n =
-  inv_hodge_star(Val{n}, s, hodge)
-@inline inv_hodge_star(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector;
+  inv_hodge_star(Val(n), s, hodge)
+@inline inv_hodge_star(::Val{n}, s::HasDeltaSet, form::AbstractVector;
                        hodge::DiscreteHodge=GeometricHodge()) where n =
-  inv_hodge_star(Val{n}, s, form, hodge)
+  inv_hodge_star(Val(n), s, form, hodge)
 
-function inv_hodge_star(::Type{Val{n}}, s::HasDeltaSet,
+function inv_hodge_star(::Val{n}, s::HasDeltaSet,
                         form::AbstractVector, ::DiagonalHodge) where n
   if iseven(n*(ndims(s)-n))
-    applydiag(form) do x, a; a / hodge_diag(Val{n},s,x) end
+    applydiag(form) do x, a; a / hodge_diag(Val(n),s,x) end
   else
-    applydiag(form) do x, a; -a / hodge_diag(Val{n},s,x) end
+    applydiag(form) do x, a; -a / hodge_diag(Val(n),s,x) end
   end
 end
 
-function inv_hodge_star(::Type{Val{n}}, s::HasDeltaSet, ::DiagonalHodge) where n
+function inv_hodge_star(::Val{n}, s::HasDeltaSet, ::DiagonalHodge) where n
   if iseven(n*(ndims(s)-n))
-    Diagonal([ 1 / hodge_diag(Val{n},s,x) for x in simplices(n,s) ])
+    Diagonal([ 1 / hodge_diag(Val(n),s,x) for x in simplices(n,s) ])
   else
-    Diagonal([ -1 / hodge_diag(Val{n},s,x) for x in simplices(n,s) ])
+    Diagonal([ -1 / hodge_diag(Val(n),s,x) for x in simplices(n,s) ])
   end
 end
 
-function inv_hodge_star(::Type{Val{1}}, s::AbstractDeltaDualComplex2D,
+function inv_hodge_star(::Val{1}, s::AbstractDeltaDualComplex2D,
                         ::GeometricHodge)
-  -1 * inv(Matrix(⋆(Val{1}, s, GeometricHodge())))
+  -1 * inv(Matrix(⋆(Val(1), s, GeometricHodge())))
 end
-function inv_hodge_star(::Type{Val{1}}, s::AbstractDeltaDualComplex2D,
+function inv_hodge_star(::Val{1}, s::AbstractDeltaDualComplex2D,
                         form::AbstractVector, ::GeometricHodge)
-  -1 * (Matrix(⋆(Val{1}, s, GeometricHodge())) \ form)
+  -1 * (Matrix(⋆(Val(1), s, GeometricHodge())) \ form)
 end
 
-inv_hodge_star(::Type{Val{0}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge) =
-  inv_hodge_star(Val{0}, s, DiagonalHodge())
-inv_hodge_star(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, ::GeometricHodge) =
-  inv_hodge_star(Val{2}, s, DiagonalHodge())
+inv_hodge_star(::Val{0}, s::AbstractDeltaDualComplex2D, ::GeometricHodge) =
+  inv_hodge_star(Val(0), s, DiagonalHodge())
+inv_hodge_star(::Val{2}, s::AbstractDeltaDualComplex2D, ::GeometricHodge) =
+  inv_hodge_star(Val(2), s, DiagonalHodge())
 
-inv_hodge_star(::Type{Val{0}}, s::AbstractDeltaDualComplex2D,
+inv_hodge_star(::Val{0}, s::AbstractDeltaDualComplex2D,
                form::AbstractVector, ::GeometricHodge) =
-  inv_hodge_star(Val{0}, s, form, DiagonalHodge())
-inv_hodge_star(::Type{Val{2}}, s::AbstractDeltaDualComplex2D,
+  inv_hodge_star(Val(0), s, form, DiagonalHodge())
+inv_hodge_star(::Val{2}, s::AbstractDeltaDualComplex2D,
                form::AbstractVector, ::GeometricHodge) =
-  inv_hodge_star(Val{2}, s, form, DiagonalHodge())
+  inv_hodge_star(Val(2), s, form, DiagonalHodge())
 
-inv_hodge_star(::Type{Val{n}}, s::AbstractDeltaDualComplex1D,
+inv_hodge_star(::Val{n}, s::AbstractDeltaDualComplex1D,
                ::GeometricHodge) where n =
-  inv_hodge_star(Val{n}, s, DiagonalHodge())
-inv_hodge_star(::Type{Val{n}}, s::AbstractDeltaDualComplex1D,
+  inv_hodge_star(Val(n), s, DiagonalHodge())
+inv_hodge_star(::Val{n}, s::AbstractDeltaDualComplex1D,
                form::AbstractVector, ::GeometricHodge) where n =
-  inv_hodge_star(Val{n}, s, form, DiagonalHodge())
+  inv_hodge_star(Val(n), s, form, DiagonalHodge())
 
 """ Alias for the inverse Hodge star operator [`⋆⁻¹`](@ref).
 """
@@ -1779,35 +1782,35 @@ const ⋆⁻¹ = inv_hodge_star
 """ Codifferential operator from primal ``n`` forms to primal ``n-1``-forms.
 """
 δ(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n =
-  SimplexForm{n-1}(δ(Val{n}, s, GeometricHodge(), x.data; kw...))
+  SimplexForm{n-1}(δ(Val(n), s, GeometricHodge(), x.data; kw...))
 @inline δ(n::Int, s::HasDeltaSet, args...; kw...) =
-  δ(Val{n}, s, args...; kw...)
-@inline δ(::Type{Val{n}}, s::HasDeltaSet; hodge::DiscreteHodge=GeometricHodge(),
+  δ(Val(n), s, args...; kw...)
+@inline δ(::Val{n}, s::HasDeltaSet; hodge::DiscreteHodge=GeometricHodge(),
           matrix_type::Type=SparseMatrixCSC{Float64}) where n =
-  δ(Val{n}, s, hodge, matrix_type)
-@inline δ(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector;
+  δ(Val(n), s, hodge, matrix_type)
+@inline δ(::Val{n}, s::HasDeltaSet, form::AbstractVector;
           hodge::DiscreteHodge=GeometricHodge()) where n =
-  δ(Val{n}, s, hodge, form)
+  δ(Val(n), s, hodge, form)
 
-function δ(::Type{Val{n}}, s::HasDeltaSet, ::DiagonalHodge, args...) where n
+function δ(::Val{n}, s::HasDeltaSet, ::DiagonalHodge, args...) where n
   # The sign of δ in Gillette's notes (see test file) is simply a product of
   # the signs for the inverse hodge and dual derivative involved.
   sgn = iseven((n-1)*(ndims(s)*(n-1) + 1)) ? +1 : -1
   operator_nz(Float64, nsimplices(n-1,s), nsimplices(n,s), args...) do x
-    c = hodge_diag(Val{n}, s, x)
-    I, V = dual_derivative_nz(Val{ndims(s)-n}, s, x)
+    c = hodge_diag(Val(n), s, x)
+    I, V = dual_derivative_nz(Val(ndims(s)-n), s, x)
     V = map(I, V) do i, a
-      sgn * c * a / hodge_diag(Val{n-1}, s, i)
+      sgn * c * a / hodge_diag(Val(n-1), s, i)
     end
     (I, V)
   end
 end
 
-function δ(::Type{Val{n}}, s::HasDeltaSet, ::GeometricHodge, matrix_type) where n
+function δ(::Val{n}, s::HasDeltaSet, ::GeometricHodge, matrix_type) where n
   inv_hodge_star(n-1, s) * dual_derivative(ndims(s)-n, s) * ⋆(n, s)
 end
 
-function δ(::Type{Val{n}}, s::HasDeltaSet, ::GeometricHodge, form::AbstractVector) where n
+function δ(::Val{n}, s::HasDeltaSet, ::GeometricHodge, form::AbstractVector) where n
   Vector(inv_hodge_star(n - 1, s, dual_derivative(ndims(s)-n, s, ⋆(n, s, form))))
 end
 
@@ -1829,13 +1832,14 @@ This linear operator on primal ``n``-forms defined by ``∇² α := -δ d α``, 
     of being consistent with the Laplace-de Rham operator [`Δ`](@ref).
 """
 ∇²(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n =
-  SimplexForm{n}(∇²(Val{n}, s, x.data; kw...))
-@inline ∇²(n::Int, s::HasDeltaSet, args...; kw...) = ∇²(Val{n}, s, args...; kw...)
+  SimplexForm{n}(∇²(Val(n), s, x.data; kw...))
+@inline ∇²(n::Int, s::HasDeltaSet, args...; kw...) =
+  ∇²(Val(n), s, args...; kw...)
 
-∇²(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector; kw...) where n =
-  -δ(n+1, s, d(Val{n}, s, form); kw...)
-∇²(::Type{Val{n}}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) where n =
-  -δ(n+1, s; matrix_type=matrix_type, kw...) * d(Val{n}, s, matrix_type)
+∇²(::Val{n}, s::HasDeltaSet, form::AbstractVector; kw...) where n =
+  -δ(n+1, s, d(Val(n), s, form); kw...)
+∇²(::Val{n}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) where n =
+  -δ(n+1, s; matrix_type=matrix_type, kw...) * d(Val(n), s, matrix_type)
 
 """ Alias for the Laplace-Beltrami operator [`∇²`](@ref).
 """
@@ -1848,29 +1852,30 @@ Restricted to 0-forms, it reduces to the negative of the Laplace-Beltrami
 operator [`∇²`](@ref): ``Δ f = -∇² f``.
 """
 Δ(s::HasDeltaSet, x::SimplexForm{n}; kw...) where n =
-  SimplexForm{n}(Δ(Val{n}, s, x.data; kw...))
-@inline Δ(n::Int, s::HasDeltaSet, args...; kw...) = Δ(Val{n}, s, args...; kw...)
+  SimplexForm{n}(Δ(Val(n), s, x.data; kw...))
+@inline Δ(n::Int, s::HasDeltaSet, args...; kw...) =
+  Δ(Val(n), s, args...; kw...)
 
-Δ(::Type{Val{0}}, s::HasDeltaSet, form::AbstractVector; kw...) =
-  δ(1, s, d(Val{0}, s, form); kw...)
-Δ(::Type{Val{0}}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) =
-  δ(1,s; matrix_type=matrix_type, kw...) * d(Val{0},s,matrix_type)
+Δ(::Val{0}, s::HasDeltaSet, form::AbstractVector; kw...) =
+  δ(1, s, d(Val(0), s, form); kw...)
+Δ(::Val{0}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) =
+  δ(1, s; matrix_type=matrix_type, kw...) * d(Val(0), s, matrix_type)
 
-Δ(::Type{Val{n}}, s::HasDeltaSet, form::AbstractVector; kw...) where n =
-  δ(n+1, s, d(Val{n}, s, form); kw...) + d(Val{n-1}, s, δ(n, s, form; kw...))
-Δ(::Type{Val{n}}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) where n =
-  δ(n+1,s; matrix_type=matrix_type, kw...) * d(Val{n},s,matrix_type) +
-		d(Val{n-1},s,matrix_type) * δ(n,s; matrix_type=matrix_type, kw...)
+Δ(::Val{n}, s::HasDeltaSet, form::AbstractVector; kw...) where n =
+  δ(n+1, s, d(Val(n), s, form); kw...) + d(Val(n-1), s, δ(n, s, form; kw...))
+Δ(::Val{n}, s::HasDeltaSet; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) where n =
+  δ(n+1, s; matrix_type=matrix_type, kw...) * d(Val(n), s, matrix_type) +
+		d(Val(n-1), s, matrix_type) * δ(n, s; matrix_type=matrix_type, kw...)
 
-Δ(::Type{Val{1}}, s::AbstractDeltaDualComplex1D, form::AbstractVector; kw...) =
-  d(Val{0}, s, δ(1, s, form; kw...))
-Δ(::Type{Val{1}}, s::AbstractDeltaDualComplex1D; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) =
-  d(Val{0},s,matrix_type) * δ(1,s; matrix_type=matrix_type, kw...)
+Δ(::Val{1}, s::AbstractDeltaDualComplex1D, form::AbstractVector; kw...) =
+  d(Val(0), s, δ(1, s, form; kw...))
+Δ(::Val{1}, s::AbstractDeltaDualComplex1D; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) =
+  d(Val(0), s, matrix_type) * δ(1, s; matrix_type=matrix_type, kw...)
 
-Δ(::Type{Val{2}}, s::AbstractDeltaDualComplex2D, form::AbstractVector; kw...) =
-  d(Val{1}, s, δ(2, s, form; kw...))
-Δ(::Type{Val{2}}, s::AbstractDeltaDualComplex2D; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) =
-  d(Val{1},s,matrix_type) * δ(2,s; matrix_type=matrix_type, kw...)
+Δ(::Val{2}, s::AbstractDeltaDualComplex2D, form::AbstractVector; kw...) =
+  d(Val(1), s, δ(2, s, form; kw...))
+Δ(::Val{2}, s::AbstractDeltaDualComplex2D; matrix_type::Type=SparseMatrixCSC{Float64}, kw...) =
+  d(Val(1), s, matrix_type) * δ(2, s; matrix_type=matrix_type, kw...)
 """ Alias for the Laplace-de Rham operator [`Δ`](@ref).
 """
 const laplace_de_rham = Δ
@@ -2018,13 +2023,13 @@ end
 
 ∧(::Type{Tuple{0,0}}, s::HasDeltaSet, f, g, x::Int) = f[x]*g[x]
 ∧(::Type{Tuple{k,0}}, s::HasDeltaSet, α, g, x::Int) where k =
-  wedge_product_zero(Val{k}, s, g, α, x)
+  wedge_product_zero(Val(k), s, g, α, x)
 ∧(::Type{Tuple{0,k}}, s::HasDeltaSet, f, β, x::Int) where k =
-  wedge_product_zero(Val{k}, s, f, β, x)
+  wedge_product_zero(Val(k), s, f, β, x)
 
 """ Wedge product of a 0-form and a ``k``-form.
 """
-function wedge_product_zero(::Type{Val{k}}, s::HasDeltaSet,
+function wedge_product_zero(::Val{k}, s::HasDeltaSet,
                             f, α, x::Int) where k
   subs = subsimplices(k, s, x)
   vs = primal_vertex(k, s, subs)
@@ -2044,7 +2049,7 @@ primal vector field (or primal 1-form) and a dual ``n``-forms and then returns a
 dual ``(n-1)``-form.
 """
 interior_product(s::HasDeltaSet, X♭::EForm, α::DualForm{n}; kw...) where n =
-  DualForm{n-1}(interior_product_flat(Val{n}, s, X♭.data, α.data); kw...)
+  DualForm{n-1}(interior_product_flat(Val(n), s, X♭.data, α.data); kw...)
 
 """ Interior product of a 1-form and a ``n``-form, yielding an ``(n-1)``-form.
 
@@ -2053,9 +2058,9 @@ assumes that the flat operator [`♭`](@ref) (not yet implemented for primal
 vector fields) has already been applied to yield a 1-form.
 """
 @inline interior_product_flat(n::Int, s::HasDeltaSet, args...; kw...) =
-  interior_product_flat(Val{n}, s, args...; kw...)
+  interior_product_flat(Val(n), s, args...; kw...)
 
-function interior_product_flat(::Type{Val{n}}, s::HasDeltaSet,
+function interior_product_flat(::Val{n}, s::HasDeltaSet,
                                X♭::AbstractVector, α::AbstractVector;
                                kw...) where n
   # TODO: Global sign `iseven(n*n′) ? +1 : -1`
@@ -2069,7 +2074,7 @@ Specifically, this is the primal-dual Lie derivative defined in (Hirani 2003,
 Section 8.4) and (Desbrun et al 2005, Section 10).
 """
 ℒ(s::HasDeltaSet, X♭::EForm, α::DualForm{n}; kw...) where n =
-  DualForm{n}(lie_derivative_flat(Val{n}, s, X♭, α.data; kw...))
+  DualForm{n}(lie_derivative_flat(Val(n), s, X♭, α.data; kw...))
 
 """ Alias for Lie derivative operator [`ℒ`](@ref).
 """
@@ -2081,20 +2086,20 @@ Assumes that the flat operator [`♭`](@ref) has already been applied to the
 vector field.
 """
 @inline lie_derivative_flat(n::Int, s::HasDeltaSet, args...; kw...) =
-  lie_derivative_flat(Val{n}, s, args...; kw...)
+  lie_derivative_flat(Val(n), s, args...; kw...)
 
-function lie_derivative_flat(::Type{Val{0}}, s::HasDeltaSet,
+function lie_derivative_flat(::Val{0}, s::HasDeltaSet,
                              X♭::AbstractVector, α::AbstractVector; kw...)
   interior_product_flat(1, s, X♭, dual_derivative(0, s, α); kw...)
 end
 
-function lie_derivative_flat(::Type{Val{1}}, s::HasDeltaSet,
+function lie_derivative_flat(::Val{1}, s::HasDeltaSet,
                              X♭::AbstractVector, α::AbstractVector; kw...)
   interior_product_flat(2, s, X♭, dual_derivative(1, s, α); kw...) +
     dual_derivative(0, s, interior_product_flat(1, s, X♭, α; kw...))
 end
 
-function lie_derivative_flat(::Type{Val{2}}, s::HasDeltaSet,
+function lie_derivative_flat(::Val{2}, s::HasDeltaSet,
                              X♭::AbstractVector, α::AbstractVector; kw...)
   dual_derivative(1, s, interior_product_flat(2, s, X♭, α; kw...))
 end

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -133,13 +133,13 @@ function wedge_kernel_coeffs(::Val{2}, ::Val{1}, sd::EmbeddedDeltaDualComplex3D{
 end
 
 # Grab the float type of the volumes of the complex.
-function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p}, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p}, backend=Val(:CPU), arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
-function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, backend=Val(:CPU), arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
-function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}, backend=Val(:CPU), arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
 
@@ -237,7 +237,7 @@ function dec_c_wedge_product(::Val{m}, ::Val{n}, α, β, wedge_cache) where {m,n
   dec_c_wedge_product!(Val(m), Val(n), res, α, β, wedge_cache[1], wedge_cache[2])
 end
 
-"""    dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing) where {m,n}
+"""    dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, backend=Val(:CPU), arr_cons=identity, cast_float=nothing) where {m,n}
 
 Return a function that computes the wedge product between a primal `m`-form and a primal `n`-form, assuming special properties of the mesh.
 
@@ -248,42 +248,43 @@ It is assumed...
 # Arguments:
 `::Val{m}, ::Val{n}`: the degrees of the differential forms.
 `sd`: the simplicial complex.
+`backend=Val(:CPU)`: a value-type to select special backend logic, if implemented.
 `arr_cons=identity`: a constructor of the desired array type on the appropriate backend e.g. `MtlArray`.
 `cast_float=nothing`: a specific Float type to use e.g. `Float32`. Otherwise, the type of the first differential form will be used.
 """
-function dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing) where {m,n}
+function dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, backend=Val(:CPU), arr_cons=identity, cast_float=nothing) where {m,n}
   error("Unsupported combination of degrees $m and $n. Ensure that their sum is not greater than the degree of the complex.")
 end
 
 dec_wedge_product(m::Int, n::Int, sd::HasDeltaSet, args...) =
   dec_wedge_product(Val(m), Val(n), sd::HasDeltaSet, args...)
 
-function dec_wedge_product(::Val{0}, ::Val{0}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing)
+function dec_wedge_product(::Val{0}, ::Val{0}, sd::HasDeltaSet, backend=Val(:CPU), arr_cons=identity, cast_float=nothing)
   (f, g) -> f .* g
 end
 
-function dec_wedge_product(::Val{k}, ::Val{0}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing) where {k}
-  wedge_cache = cache_wedge(Val(0), Val(k), sd, arr_cons, cast_float)
+function dec_wedge_product(::Val{k}, ::Val{0}, sd::HasDeltaSet, backend=Val(:CPU), arr_cons=identity, cast_float=nothing) where {k}
+  wedge_cache = cache_wedge(Val(0), Val(k), sd, backend, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(0), Val(k), β, α, wedge_cache)
 end
 
-function dec_wedge_product(::Val{0}, ::Val{k}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing) where {k}
-  wedge_cache = cache_wedge(Val(0), Val(k), sd, arr_cons, cast_float)
+function dec_wedge_product(::Val{0}, ::Val{k}, sd::HasDeltaSet, backend=Val(:CPU), arr_cons=identity, cast_float=nothing) where {k}
+  wedge_cache = cache_wedge(Val(0), Val(k), sd, backend, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(0), Val(k), α, β, wedge_cache)
 end
 
-function dec_wedge_product(::Val{1}, ::Val{1}, sd::HasDeltaSet2D, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Val(1), Val(1), sd, arr_cons, cast_float)
+function dec_wedge_product(::Val{1}, ::Val{1}, sd::HasDeltaSet2D, backend=Val(:CPU), arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(1), Val(1), sd, backend, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(1), Val(1), α, β, wedge_cache)
 end
 
-function dec_wedge_product(::Val{1}, ::Val{2}, sd::HasDeltaSet3D, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Val(2), Val(1), sd, arr_cons, cast_float)
+function dec_wedge_product(::Val{1}, ::Val{2}, sd::HasDeltaSet3D, backend=Val(:CPU), arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(2), Val(1), sd, backend, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(2), Val(1), β, α, wedge_cache)
 end
 
-function dec_wedge_product(::Val{2}, ::Val{1}, sd::HasDeltaSet3D, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Val(2), Val(1), sd, arr_cons, cast_float)
+function dec_wedge_product(::Val{2}, ::Val{1}, sd::HasDeltaSet3D, backend=Val(:CPU), arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(2), Val(1), sd, backend, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(2), Val(1), α, β, wedge_cache)
 end
 

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -39,13 +39,15 @@ export dec_wedge_product, cache_wedge, dec_c_wedge_product, dec_c_wedge_product!
 #--------------
 
 # Cache coefficients to be used by wedge product kernels.
-function wedge_kernel_coeffs(::Type{Tuple{0,1}}, sd::Union{EmbeddedDeltaDualComplex1D, EmbeddedDeltaDualComplex2D, EmbeddedDeltaDualComplex3D})
-  (hcat(convert(Vector{Int32}, sd[:∂v0])::Vector{Int32}, convert(Vector{Int32}, sd[:∂v1])::Vector{Int32}),
-    ne(sd))
+function wedge_kernel_coeffs(::Val{0}, ::Val{1}, sd::Union{EmbeddedDeltaDualComplex1D, EmbeddedDeltaDualComplex2D, EmbeddedDeltaDualComplex3D})
+  (
+   hcat(convert(Vector{Int32}, sd[:∂v0])::Vector{Int32},
+        convert(Vector{Int32}, sd[:∂v1])::Vector{Int32}),
+   ne(sd))
 end
 
 # TODO: Tagging `shift` as `::Int` can sometimes increase efficiency.
-function wedge_kernel_coeffs(::Type{Tuple{0,2}}, sd::Union{EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, EmbeddedDeltaDualComplex3D{Bool, float_type, _p}}) where {float_type, _p}
+function wedge_kernel_coeffs(::Val{0}, ::Val{2}, sd::Union{EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, EmbeddedDeltaDualComplex3D{Bool, float_type, _p}}) where {float_type, _p}
   verts = Array{Int32}(undef, 6, ntriangles(sd))
   coeffs = Array{float_type}(undef, 6, ntriangles(sd))
   shift = ntriangles(sd)
@@ -59,7 +61,7 @@ function wedge_kernel_coeffs(::Type{Tuple{0,2}}, sd::Union{EmbeddedDeltaDualComp
   (verts, coeffs, ntriangles(sd))
 end
 
-function wedge_kernel_coeffs(::Type{Tuple{0,3}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}) where {float_type, _p}
+function wedge_kernel_coeffs(::Val{0}, ::Val{3}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}) where {float_type, _p}
   verts = Array{Int32}(undef, 24, ntetrahedra(sd))
   coeffs = Array{float_type}(undef, 24, ntetrahedra(sd))
   stride = 24
@@ -73,7 +75,7 @@ function wedge_kernel_coeffs(::Type{Tuple{0,3}}, sd::EmbeddedDeltaDualComplex3D{
   (verts, coeffs, ntetrahedra(sd))
 end
 
-function wedge_kernel_coeffs(::Type{Tuple{1,1}}, sd::Union{EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, EmbeddedDeltaDualComplex3D{Bool, float_type, _p}}) where {float_type, _p}
+function wedge_kernel_coeffs(::Val{1}, ::Val{1}, sd::Union{EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, EmbeddedDeltaDualComplex3D{Bool, float_type, _p}}) where {float_type, _p}
   coeffs = Array{float_type}(undef, 3, ntriangles(sd))
   shift = ntriangles(sd)
   e = Array{Int32}(undef, 3, ntriangles(sd))
@@ -91,7 +93,7 @@ function wedge_kernel_coeffs(::Type{Tuple{1,1}}, sd::Union{EmbeddedDeltaDualComp
 end
 
 # TODO: Improve generatation of coefficients
-function wedge_kernel_coeffs(::Type{Tuple{2,1}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}) where {float_type, _p}
+function wedge_kernel_coeffs(::Val{2}, ::Val{1}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}) where {float_type, _p}
   coeffs = Array{float_type}(undef, 12, ntetrahedra(sd))
   ets = Array{Int32}(undef, 10, ntetrahedra(sd))
 
@@ -131,20 +133,20 @@ function wedge_kernel_coeffs(::Type{Tuple{2,1}}, sd::EmbeddedDeltaDualComplex3D{
 end
 
 # Grab the float type of the volumes of the complex.
-function cache_wedge(::Type{Tuple{m,n}}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
-function cache_wedge(::Type{Tuple{m,n}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
-function cache_wedge(::Type{Tuple{m,n}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
 
 # Grab wedge kernel coeffs and cast.
 function cache_wedge(m::Int, n::Int, sd::HasDeltaSet1D, float_type::DataType, arr_cons, cast_float::Union{Nothing, DataType})
   ft = isnothing(cast_float) ? float_type : cast_float
-  wc = wedge_kernel_coeffs(Tuple{m,n}, sd)
+  wc = wedge_kernel_coeffs(Val(m), Val(n), sd)
   if wc[2] isa Matrix
     (arr_cons(wc[1]), arr_cons(Matrix{ft}(wc[2])), wc[3])
   else
@@ -212,7 +214,7 @@ end
 
 # Manually dispatch, since CUDA.jl kernels cannot.
 # Alternatively, wrap each wedge_kernel separately.
-function dec_c_wedge_product!(::Type{Tuple{j,k}}, res, α, β, p, c) where {j,k}
+function dec_c_wedge_product!(::Val{j}, ::Val{k}, res, α, β, p, c) where {j,k}
   kernel_function = if (j,k) == (0,1)
     wedge_kernel_01!
   elseif (j,k) == (0,2)
@@ -229,13 +231,13 @@ function dec_c_wedge_product!(::Type{Tuple{j,k}}, res, α, β, p, c) where {j,k}
   auto_select_backend(kernel_function, res, α, β, p, c)
 end
 
-function dec_c_wedge_product(::Type{Tuple{m,n}}, α, β, wedge_cache) where {m,n}
+function dec_c_wedge_product(::Val{m}, ::Val{n}, α, β, wedge_cache) where {m,n}
   α_data = α isa SimplexForm ? α.data : α
   res = KernelAbstractions.zeros(get_backend(α_data), eltype(α_data), last(wedge_cache))
-  dec_c_wedge_product!(Tuple{m,n}, res, α, β, wedge_cache[1], wedge_cache[2])
+  dec_c_wedge_product!(Val(m), Val(n), res, α, β, wedge_cache[1], wedge_cache[2])
 end
 
-"""    dec_wedge_product(::Type{Tuple{m,n}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {m,n}
+"""    dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {m,n}
 
 Return a function that computes the wedge product between a primal `m`-form and a primal `n`-form, assuming special properties of the mesh.
 
@@ -244,46 +246,46 @@ It is assumed...
 ... for the 1-1 wedge product, that the dual mesh simplices are in the default order as returned by the dual complex constructor.
 
 # Arguments:
-`Tuple{m,n}`: the degrees of the differential forms.
+`::Val{m}, ::Val{n}`: the degrees of the differential forms.
 `sd`: the simplicial complex.
 `backend=Val{:CPU}`: a value-type to select special backend logic, if implemented.
 `arr_cons=identity`: a constructor of the desired array type on the appropriate backend e.g. `MtlArray`.
 `cast_float=nothing`: a specific Float type to use e.g. `Float32`. Otherwise, the type of the first differential form will be used.
 """
-function dec_wedge_product(::Type{Tuple{m,n}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {m,n}
+function dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {m,n}
   error("Unsupported combination of degrees $m and $n. Ensure that their sum is not greater than the degree of the complex.")
 end
 
-dec_wedge_product(m::Int, n::Int, sd::HasDeltaSet) =
-  dec_wedge_product(Tuple{m,n}, sd::HasDeltaSet)
+dec_wedge_product(m::Int, n::Int, sd::HasDeltaSet, args...) =
+  dec_wedge_product(Val(m), Val(n), sd::HasDeltaSet, args...)
 
-function dec_wedge_product(::Type{Tuple{0,0}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+function dec_wedge_product(::Val{0}, ::Val{0}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
   (f, g) -> f .* g
 end
 
-function dec_wedge_product(::Type{Tuple{k,0}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {k}
-  wedge_cache = cache_wedge(Tuple{0,k}, sd, backend, arr_cons, cast_float)
-  (α, β) -> dec_c_wedge_product(Tuple{0,k}, β, α, wedge_cache)
+function dec_wedge_product(::Val{k}, ::Val{0}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {k}
+  wedge_cache = cache_wedge(Val(0), Val(k), sd, backend, arr_cons, cast_float)
+  (α, β) -> dec_c_wedge_product(Val(0), Val(k), β, α, wedge_cache)
 end
 
-function dec_wedge_product(::Type{Tuple{0,k}}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {k}
-  wedge_cache = cache_wedge(Tuple{0,k}, sd, backend, arr_cons, cast_float)
-  (α, β) -> dec_c_wedge_product(Tuple{0,k}, α, β, wedge_cache)
+function dec_wedge_product(::Val{0}, ::Val{k}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {k}
+  wedge_cache = cache_wedge(Val(0), Val(k), sd, backend, arr_cons, cast_float)
+  (α, β) -> dec_c_wedge_product(Val(0), Val(k), α, β, wedge_cache)
 end
 
-function dec_wedge_product(::Type{Tuple{1,1}}, sd::HasDeltaSet2D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Tuple{1,1}, sd, backend, arr_cons, cast_float)
-  (α, β) -> dec_c_wedge_product(Tuple{1,1}, α, β, wedge_cache)
+function dec_wedge_product(::Val{1}, ::Val{1}, sd::HasDeltaSet2D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(1), Val(1), sd, backend, arr_cons, cast_float)
+  (α, β) -> dec_c_wedge_product(Val(1), Val(1), α, β, wedge_cache)
 end
 
-function dec_wedge_product(::Type{Tuple{1,2}}, sd::HasDeltaSet3D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Tuple{2,1}, sd, backend, arr_cons, cast_float)
-  (α, β) -> dec_c_wedge_product(Tuple{2,1}, β, α, wedge_cache)
+function dec_wedge_product(::Val{1}, ::Val{2}, sd::HasDeltaSet3D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(2), Val(1), sd, backend, arr_cons, cast_float)
+  (α, β) -> dec_c_wedge_product(Val(2), Val(1), β, α, wedge_cache)
 end
 
-function dec_wedge_product(::Type{Tuple{2,1}}, sd::HasDeltaSet3D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Tuple{2,1}, sd, backend, arr_cons, cast_float)
-  (α, β) -> dec_c_wedge_product(Tuple{2,1}, α, β, wedge_cache)
+function dec_wedge_product(::Val{2}, ::Val{1}, sd::HasDeltaSet3D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(2), Val(1), sd, backend, arr_cons, cast_float)
+  (α, β) -> dec_c_wedge_product(Val(2), Val(1), α, β, wedge_cache)
 end
 
 # Return a matrix that can be multiplied to a dual 0-form, before being
@@ -302,22 +304,22 @@ function wedge_dd_01_mat(sd::HasDeltaSet)
   m
 end
 
-"""    dec_wedge_product_dd(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+"""    dec_wedge_product_dd(::Val{m}, ::Val{n}, sd::HasDeltaSet) where {m,n}
 
 Return a function that computes the wedge product between a dual `m`-form and a dual `n`-form.
 
 The currently supported dual-dual wedges are 0-1 and 1-0.
 """
-function dec_wedge_product_dd(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+function dec_wedge_product_dd(::Val{m}, ::Val{n}, sd::HasDeltaSet) where {m,n}
   error("Unsupported combination of degrees $m and $n. Ensure that their sum is not greater than the degree of the complex. The currently supported dual-dual wedges are 0-1 and 1-0.")
 end
 
-function dec_wedge_product_dd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
+function dec_wedge_product_dd(::Val{0}, ::Val{1}, sd::HasDeltaSet)
   m = wedge_dd_01_mat(sd)
   (f,g) -> (m * f) .* g
 end
 
-function dec_wedge_product_dd(::Type{Tuple{1,0}}, sd::HasDeltaSet)
+function dec_wedge_product_dd(::Val{1}, ::Val{0}, sd::HasDeltaSet)
   m = wedge_dd_01_mat(sd)
   (f,g) -> f .* (m * g)
 end
@@ -344,7 +346,16 @@ function wedge_pd_01_mat(sd::HasDeltaSet)
   m
 end
 
-"""    dec_wedge_product_dp(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+dec_wedge_product_pd(m::Int, n::Int, sd::HasDeltaSet) =
+  dec_wedge_product_pd(Val(m), Val(n), sd::HasDeltaSet)
+
+dec_wedge_product_dp(m::Int, n::Int, sd::HasDeltaSet) =
+  dec_wedge_product_dp(Val(m), Val(n), sd::HasDeltaSet)
+
+dec_wedge_product_dd(m::Int, n::Int, sd::HasDeltaSet) =
+  dec_wedge_product_dd(Val(m), Val(n), sd::HasDeltaSet)
+
+"""    dec_wedge_product_dp(::Val{m}, ::Val{n}, sd::HasDeltaSet) where {m,n}
 
 Return a function that computes the wedge product between a dual `m`-form and a primal `n`-form.
 
@@ -353,39 +364,39 @@ It is assumed...
 
 The currently supported dual-primal wedges are 0-1, 1-0, and 1-1.
 """
-function dec_wedge_product_dp(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+function dec_wedge_product_dp(::Val{m}, ::Val{n}, sd::HasDeltaSet) where {m,n}
   error("Unsupported combination of degrees $m and $n. Ensure that their sum is not greater than the degree of the complex. The currently supported dual-primal wedges are 0-1, 1-0, and 1-1.")
 end
 
-"""    dec_wedge_product_pd(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+"""    dec_wedge_product_pd(::Val{m}, ::Val{n}, sd::HasDeltaSet) where {m,n}
 
 Return a function that computes the wedge product between a primal `m`-form and a dual `n`-form.
 
 See [`dec_wedge_product_dp`](@ref) for assumptions.
 """
-function dec_wedge_product_pd(::Type{Tuple{m,n}}, sd::HasDeltaSet) where {m,n}
+function dec_wedge_product_pd(::Val{m}, ::Val{n}, sd::HasDeltaSet) where {m,n}
   error("Unsupported combination of degrees $m and $n. Ensure that their sum is not greater than the degree of the complex. The currently supported primal-dual wedges are 0-1, 1-0, and 1-1.")
 end
 
-function dec_wedge_product_dp(::Type{Tuple{1,0}}, sd::HasDeltaSet)
+function dec_wedge_product_dp(::Val{1}, ::Val{0}, sd::HasDeltaSet)
   m = wedge_pd_01_mat(sd)
   (f,g) -> f .* (m * g)
 end
 
-function dec_wedge_product_pd(::Type{Tuple{0,1}}, sd::HasDeltaSet)
+function dec_wedge_product_pd(::Val{0}, ::Val{1}, sd::HasDeltaSet)
   m = wedge_pd_01_mat(sd)
   (g,f) -> (m * g) .* f
 end
 
-function dec_wedge_product_pd(::Type{Tuple{1,1}}, sd::HasDeltaSet)
+function dec_wedge_product_pd(::Val{1}, ::Val{1}, sd::HasDeltaSet)
   ♭♯_m = ♭♯_mat(sd)
-  Λ_cached = dec_wedge_product(Tuple{1, 1}, sd)
+  Λ_cached = dec_wedge_product(Val(1), Val(1), sd)
   (f, g) -> Λ_cached(f, ♭♯_m * g)
 end
 
-function dec_wedge_product_dp(::Type{Tuple{1,1}}, sd::HasDeltaSet)
+function dec_wedge_product_dp(::Val{1}, ::Val{1}, sd::HasDeltaSet)
   ♭♯_m = ♭♯_mat(sd)
-  Λ_cached = dec_wedge_product(Tuple{1, 1}, sd)
+  Λ_cached = dec_wedge_product(Val(1), Val(1), sd)
   (f, g) -> Λ_cached(♭♯_m * f, g)
 end
 
@@ -398,7 +409,7 @@ Chain the musical isomorphisms to interpolate the dual 1-form to a primal
 version of the Hirani primal-primal weddge.
 """
 ∧(s::HasDeltaSet, α::SimplexForm{1}, β::DualForm{1}) =
-  dec_wedge_product_pd(Tuple{1,1}, s)(α, β)
+  dec_wedge_product_pd(Val(1), Val(1), s)(α, β)
 
 """    ∧(s::HasDeltaSet, α::DualForm{1}, β::SimplexForm{1})
 
@@ -409,7 +420,7 @@ Chain the musical isomorphisms to interpolate the dual 1-form to a primal
 weddge (without explicitly dividing by 2.)
 """
 ∧(s::HasDeltaSet, α::DualForm{1}, β::SimplexForm{1}) =
-  dec_wedge_product_dp(Tuple{1,1}, s)(α, β)
+  dec_wedge_product_dp(Val(1), Val(1), s)(α, β)
 
 
 # Boundary and Co-boundary
@@ -419,42 +430,45 @@ weddge (without explicitly dividing by 2.)
 
 Return the boundary operator (as a matrix) for `(n+1)`-simplices to `(n)`-simplices
 """
-dec_boundary(n::Int, sd::HasDeltaSet) = sparse(dec_p_boundary(Val{n}, sd)...)
+dec_boundary(n::Int, sd::HasDeltaSet) =
+  sparse(dec_p_boundary(Val(n), sd)...)
 
-dec_p_boundary(::Type{Val{k}}, sd::HasDeltaSet; negate::Bool=false) where {k} =
-  dec_p_derivbound(Val{k - 1}, sd, transpose=true, negate=negate)
+dec_p_boundary(::Val{k}, sd::HasDeltaSet; negate::Bool=false) where {k} =
+  dec_p_derivbound(Val(k-1), sd, transpose=true, negate=negate)
 
 """    dec_dual_derivative(n::Int, sd::HasDeltaSet)
 
 Return the dual exterior derivative (as a matrix) between dual `n`-simplices and dual `(n+1)`-simplices
 """
-dec_dual_derivative(n::Int, sd::HasDeltaSet) = sparse(dec_p_dual_derivative(Val{n}, sd)...)
+dec_dual_derivative(n::Int, sd::HasDeltaSet) =
+  sparse(dec_p_dual_derivative(Val(n), sd)...)
 
-dec_p_dual_derivative(::Type{Val{0}}, sd::HasDeltaSet1D) =
-  dec_p_boundary(Val{1}, sd, negate=true)
+dec_p_dual_derivative(::Val{0}, sd::HasDeltaSet1D) =
+  dec_p_boundary(Val(1), sd, negate=true)
 
-dec_p_dual_derivative(::Type{Val{0}}, sd::HasDeltaSet2D) =
-  dec_p_boundary(Val{2}, sd)
+dec_p_dual_derivative(::Val{0}, sd::HasDeltaSet2D) =
+  dec_p_boundary(Val(2), sd)
 
-dec_p_dual_derivative(::Type{Val{1}}, sd::HasDeltaSet2D) =
-  dec_p_boundary(Val{1}, sd, negate=true)
+dec_p_dual_derivative(::Val{1}, sd::HasDeltaSet2D) =
+  dec_p_boundary(Val(1), sd, negate=true)
 
-dec_p_dual_derivative(::Type{Val{0}}, sd::HasDeltaSet3D) =
-  dec_p_boundary(Val{3}, sd, negate=true)
+dec_p_dual_derivative(::Val{0}, sd::HasDeltaSet3D) =
+  dec_p_boundary(Val(3), sd, negate=true)
 
-dec_p_dual_derivative(::Type{Val{1}}, sd::HasDeltaSet3D) =
-  dec_p_boundary(Val{2}, sd)
+dec_p_dual_derivative(::Val{1}, sd::HasDeltaSet3D) =
+  dec_p_boundary(Val(2), sd)
 
-dec_p_dual_derivative(::Type{Val{2}}, sd::HasDeltaSet3D) =
-  dec_p_boundary(Val{1}, sd, negate=true)
+dec_p_dual_derivative(::Val{2}, sd::HasDeltaSet3D) =
+  dec_p_boundary(Val(1), sd, negate=true)
 
 """    dec_differential(n::Int, sd::HasDeltaSet)
 
 Return the exterior derivative (as a matrix) between `n`-simplices and `(n+1)`-simplices
 """
-dec_differential(n::Int, sd::HasDeltaSet) = sparse(dec_p_derivbound(Val{n}, sd)...)
+dec_differential(n::Int, sd::HasDeltaSet) =
+  sparse(dec_p_derivbound(Val(n), sd)...)
 
-function dec_p_derivbound(::Type{Val{0}}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
+function dec_p_derivbound(::Val{0}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
   vec_size = 2 * ne(sd)
   I = Vector{Int32}(undef, vec_size)
   J = Vector{Int32}(undef, vec_size)
@@ -479,7 +493,7 @@ function dec_p_derivbound(::Type{Val{0}}, sd::HasDeltaSet; transpose::Bool=false
   (I, J, V)
 end
 
-function dec_p_derivbound(::Type{Val{1}}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
+function dec_p_derivbound(::Val{1}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
   vec_size = 3 * ntriangles(sd)
   I = Vector{Int32}(undef, vec_size)
   J = Vector{Int32}(undef, vec_size)
@@ -509,7 +523,7 @@ function dec_p_derivbound(::Type{Val{1}}, sd::HasDeltaSet; transpose::Bool=false
   (I, J, V)
 end
 
-function dec_p_derivbound(::Type{Val{2}}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
+function dec_p_derivbound(::Val{2}, sd::HasDeltaSet; transpose::Bool=false, negate::Bool=false)
   vec_size = 4 * ntetrahedra(sd)
   I = Vector{Int32}(undef, vec_size)
   J = Vector{Int32}(undef, vec_size)
@@ -545,7 +559,7 @@ end
 # Diagonal Hodge Star
 #--------------------
 
-function dec_p_hodge_diag(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p) where float_type
+function dec_p_hodge_diag(::Val{0}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p) where float_type
   nvsd = nv(sd)
   h_0 = zeros(float_type, nvsd)
   for de in parts(sd, :DualE)
@@ -557,13 +571,13 @@ function dec_p_hodge_diag(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex1D{Bool, f
   h_0
 end
 
-function dec_p_hodge_diag(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p) where float_type
-  vols::Vector{float_type} = volume(Val{1}, sd, edges(sd))
+function dec_p_hodge_diag(::Val{1}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p} where _p) where float_type
+  vols::Vector{float_type} = volume(Val(1), sd, edges(sd))
   1 ./ vols
 end
 
 
-function dec_p_hodge_diag(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
+function dec_p_hodge_diag(::Val{0}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
   h_0 = zeros(float_type, nv(sd))
   for dt in parts(sd, :DualTri)
     v = sd[sd[dt, :D_∂e1], :D_∂v1]
@@ -572,7 +586,7 @@ function dec_p_hodge_diag(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex2D{Bool, f
   h_0
 end
 
-function dec_p_hodge_diag(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
+function dec_p_hodge_diag(::Val{1}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
   nvsd, nesd = nv(sd), ne(sd)
   h_1 = zeros(float_type, nesd)
   for de in parts(sd, :DualE)
@@ -584,37 +598,38 @@ function dec_p_hodge_diag(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D{Bool, f
   h_1
 end
 
-function dec_p_hodge_diag(::Type{Val{2}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
+function dec_p_hodge_diag(::Val{2}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p} where _p) where float_type
   tri_areas::Vector{float_type} = sd[:area]
   1 ./ tri_areas
 end
 
 # TODO: Improve the generation of these 3D hodge stars
-function dec_p_hodge_diag(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
+function dec_p_hodge_diag(::Val{0}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
   h_0 = zeros(float_type, nv(sd))
   for v in vertices(sd)
-    h_0[v] = sum(sd[elementary_duals(Val{0},sd,v), :dual_vol])
+    h_0[v] = sum(sd[elementary_duals(Val(0),sd,v), :dual_vol])
   end
   h_0
 end
 
-function dec_p_hodge_diag(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
+function dec_p_hodge_diag(::Val{1}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
   h_1 = zeros(float_type, ne(sd))
   for e in edges(sd)
-    h_1[e] = sum(dual_volume(Val{2}, sd, elementary_duals(Val{1},sd,e))) / volume(Val{1},sd,e)
+    h_1[e] = sum(dual_volume(Val(2), sd, elementary_duals(Val(1),sd,e))) /
+      volume(Val(1),sd,e)
   end
   h_1
 end
 
-function dec_p_hodge_diag(::Type{Val{2}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
+function dec_p_hodge_diag(::Val{2}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
   h_2 = zeros(float_type, ntriangles(sd))
   for t in triangles(sd)
-    h_2[t] = sum(dual_volume(Val{1}, sd, elementary_duals(Val{2},sd,t))) / volume(Val{2},sd,t)
+    h_2[t] = sum(dual_volume(Val(1), sd, elementary_duals(Val(2),sd,t))) / volume(Val(2),sd,t)
   end
   h_2
 end
 
-function dec_p_hodge_diag(::Type{Val{3}}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
+function dec_p_hodge_diag(::Val{3}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p} where _p) where float_type
   tet_volumes::Vector{float_type} = sd[:vol]
   1 ./ tet_volumes
 end
@@ -624,25 +639,25 @@ end
 Return the hodge matrix between `n`-simplices and dual 'n'-simplices.
 """
 dec_hodge_star(n::Int, sd::HasDeltaSet; hodge=GeometricHodge()) =
-  dec_hodge_star(Val{n}, sd, hodge)
+  dec_hodge_star(Val(n), sd, hodge)
 dec_hodge_star(n::Int, sd::HasDeltaSet, ::DiagonalHodge) =
-  dec_hodge_star(Val{n}, sd, DiagonalHodge())
+  dec_hodge_star(Val(n), sd, DiagonalHodge())
 dec_hodge_star(n::Int, sd::HasDeltaSet, ::GeometricHodge) =
-  dec_hodge_star(Val{n}, sd, GeometricHodge())
-dec_hodge_star(::Type{Val{k}}, sd::HasDeltaSet, ::DiagonalHodge) where {k} =
-  Diagonal(dec_p_hodge_diag(Val{k}, sd))
+  dec_hodge_star(Val(n), sd, GeometricHodge())
+dec_hodge_star(::Val{k}, sd::HasDeltaSet, ::DiagonalHodge) where {k} =
+  Diagonal(dec_p_hodge_diag(Val(k), sd))
 
 # Geometric Hodge Star
 #---------------------
 
 # TODO: Still need better implementation for Hodge 1 in 2D
-dec_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex1D, ::GeometricHodge) where {j} =
-  dec_hodge_star(Val{j}, sd, DiagonalHodge())
+dec_hodge_star(::Val{j}, sd::EmbeddedDeltaDualComplex1D, ::GeometricHodge) where {j} =
+  dec_hodge_star(Val(j), sd, DiagonalHodge())
 
-dec_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge) where {j} =
-  dec_hodge_star(Val{j}, sd, DiagonalHodge())
+dec_hodge_star(::Val{j}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge) where {j} =
+  dec_hodge_star(Val(j), sd, DiagonalHodge())
 
-function dec_hodge_star(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, point_type}, ::GeometricHodge) where {float_type, point_type}
+function dec_hodge_star(::Val{1}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, point_type}, ::GeometricHodge) where {float_type, point_type}
   I = Vector{Int32}(undef, ntriangles(sd) * 9)
   J = Vector{Int32}(undef, ntriangles(sd) * 9)
   V = Vector{float_type}(undef, ntriangles(sd) * 9)
@@ -708,75 +723,81 @@ end
 Return the inverse hodge matrix between dual `n`-simplices and 'n'-simplices.
 """
 dec_inv_hodge_star(n::Int, sd::HasDeltaSet; hodge=GeometricHodge()) =
-  dec_inv_hodge_star(Val{n}, sd, hodge)
+  dec_inv_hodge_star(Val(n), sd, hodge)
 dec_inv_hodge_star(n::Int, sd::HasDeltaSet, ::DiagonalHodge) =
-  dec_inv_hodge_star(Val{n}, sd, DiagonalHodge())
+  dec_inv_hodge_star(Val(n), sd, DiagonalHodge())
 dec_inv_hodge_star(n::Int, sd::HasDeltaSet, ::GeometricHodge) =
-  dec_inv_hodge_star(Val{n}, sd, GeometricHodge())
+  dec_inv_hodge_star(Val(n), sd, GeometricHodge())
 
-function dec_inv_hodge_star(::Type{Val{k}}, sd::HasDeltaSet, ::DiagonalHodge) where {k}
-  hdg = dec_p_hodge_diag(Val{k}, sd)
+function dec_inv_hodge_star(::Val{k}, sd::HasDeltaSet, ::DiagonalHodge) where {k}
+  hdg = dec_p_hodge_diag(Val(k), sd)
   mult_term = iseven(k * (ndims(sd) - k)) ? 1 : -1
   hdg .= (1 ./ hdg) .* mult_term
   Diagonal(hdg)
 end
 
-dec_inv_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex1D, ::GeometricHodge) where {j} =
-  dec_inv_hodge_star(Val{j}, sd, DiagonalHodge())
+dec_inv_hodge_star(::Val{j}, sd::EmbeddedDeltaDualComplex1D, ::GeometricHodge) where {j} =
+  dec_inv_hodge_star(Val(j), sd, DiagonalHodge())
 
-dec_inv_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge) where {j} =
-  dec_inv_hodge_star(Val{j}, sd, DiagonalHodge())
+dec_inv_hodge_star(::Val{j}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge) where {j} =
+  dec_inv_hodge_star(Val(j), sd, DiagonalHodge())
 
-function dec_inv_hodge_star(::Type{Val{1}}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge)
+function dec_inv_hodge_star(::Val{1}, sd::EmbeddedDeltaDualComplex2D, ::GeometricHodge)
   hdg_lu = factorize(-1 * dec_hodge_star(1, sd, GeometricHodge()))
   x -> hdg_lu \ x
 end
 
-dec_inv_hodge_star(::Type{Val{0}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) =
-  dec_inv_hodge_star(Val{0}, sd, DiagonalHodge())
+dec_inv_hodge_star(::Val{0}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) =
+  dec_inv_hodge_star(Val(0), sd, DiagonalHodge())
 
-dec_inv_hodge_star(::Type{Val{3}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) =
-  dec_inv_hodge_star(Val{3}, sd, DiagonalHodge())
+dec_inv_hodge_star(::Val{3}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) =
+  dec_inv_hodge_star(Val(3), sd, DiagonalHodge())
 
-dec_inv_hodge_star(::Type{Val{j}}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) where {j} =
+dec_inv_hodge_star(::Val{j}, sd::EmbeddedDeltaDualComplex3D, ::GeometricHodge) where {j} =
   @error "The Geometric Hodge star in 3D for 1-forms and 2-forms has not yet been implemented. Please use the Diagonal Hodge star instead."
 
 # Interior Product and Lie Derivative
 #------------------------------------
 
-"""    function interior_product_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
+interior_product_dd(m::Int, n::Int, sd::HasDeltaSet) =
+  interior_product_dd(Val(m), Val(n), sd::HasDeltaSet)
+
+"""    function interior_product_dd(::Val{1}, ::Val{1}, s::SimplicialSets.HasDeltaSet)
 
 Given a dual 1-form and a dual 1-form, return their interior product as a dual 0-form.
 """
-function interior_product_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
-  ihs1 = dec_inv_hodge_star(Val{1}, s, GeometricHodge())
-  Λ11 = dec_wedge_product_pd(Tuple{1,1}, s)
-  hs2 = dec_hodge_star(Val{2}, s, GeometricHodge())
+function interior_product_dd(::Val{1}, ::Val{1}, s::SimplicialSets.HasDeltaSet)
+  ihs1 = dec_inv_hodge_star(Val(1), s, GeometricHodge())
+  Λ11 = dec_wedge_product_pd(Val(1), Val(1), s)
+  hs2 = dec_hodge_star(Val(2), s, GeometricHodge())
   (f,g) -> hs2 * Λ11(ihs1(g), f)
 end
 
-"""    function interior_product_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
+"""    function interior_product_dd(::Val{1}, ::Val{2}, s::SimplicialSets.HasDeltaSet)
 
 Given a dual 1-form and a dual 2-form, return their interior product as a dual 1-form.
 """
-function interior_product_dd(::Type{Tuple{1,2}}, s::SimplicialSets.HasDeltaSet)
-  ihs0 = dec_inv_hodge_star(Val{0}, s, GeometricHodge())
-  hs1 = dec_hodge_star(Val{1}, s, GeometricHodge())
+function interior_product_dd(::Val{1}, ::Val{2}, s::SimplicialSets.HasDeltaSet)
+  ihs0 = dec_inv_hodge_star(Val(0), s, GeometricHodge())
+  hs1 = dec_hodge_star(Val(1), s, GeometricHodge())
   ♭♯_m = ♭♯_mat(s)
   Λ01_m = wedge_pd_01_mat(s)
   (f,g) -> hs1 * ♭♯_m * ((Λ01_m * ihs0 * g) .* f)
 end
 
-"""    function ℒ_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
+ℒ_dd(m::Int, n::Int, sd::HasDeltaSet) =
+  ℒ_dd(Val(m), Val(n), sd::HasDeltaSet)
+
+"""    function ℒ_dd(::Val{1}, ::Val{1}, s::SimplicialSets.HasDeltaSet)
 
 Given a dual 1-form and a dual 1-form, return their lie derivative as a dual 1-form.
 """
-function ℒ_dd(::Type{Tuple{1,1}}, s::SimplicialSets.HasDeltaSet)
+function ℒ_dd(::Val{1}, ::Val{1}, s::SimplicialSets.HasDeltaSet)
   # ℒ := -diuv - iduv
   d0 = dec_dual_derivative(0, s)
   d1 = dec_dual_derivative(1, s)
-  i1 = interior_product_dd(Tuple{1,1}, s)
-  i2 = interior_product_dd(Tuple{1,2}, s)
+  i1 = interior_product_dd(Val(1), Val(1), s)
+  i2 = interior_product_dd(Val(1), Val(2), s)
   (f,g) -> -(d0 * i1(f,g)) - i2(f,d1 * g)
 end
 
@@ -785,11 +806,11 @@ const lie_derivative_dd = ℒ_dd
 # Laplacian
 #----------
 
-"""    function Δᵈ_mat(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet)
+"""    function Δᵈ_mat(::Val{0}, s::SimplicialSets.HasDeltaSet)
 
 Return a function matrix encoding the dual 0-form Laplacian.
 """
-function Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet)
+function Δᵈ(::Val{0}, s::SimplicialSets.HasDeltaSet)
   dd0 = dec_dual_derivative(0, s);
   ihs1 = dec_inv_hodge_star(0, s, GeometricHodge());
   d1 = dec_differential(0,s);
@@ -798,7 +819,7 @@ function Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet)
   x -> m * x
 end
 
-function Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet2D)
+function Δᵈ(::Val{0}, s::SimplicialSets.HasDeltaSet2D)
   dd0 = dec_dual_derivative(0, s);
   ihs1 = dec_inv_hodge_star(1, s, GeometricHodge());
   d1 = dec_differential(1,s);
@@ -808,7 +829,7 @@ function Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet2D)
   x -> m * ihs1(dd0 * x)
 end
 
-function Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet3D)
+function Δᵈ(::Val{0}, s::SimplicialSets.HasDeltaSet3D)
   dd0 = dec_dual_derivative(0, s);
   ihs2 = dec_inv_hodge_star(2, s, DiagonalHodge());
   d2 = dec_differential(2,s);
@@ -817,11 +838,11 @@ function Δᵈ(::Type{Val{0}}, s::SimplicialSets.HasDeltaSet3D)
   x -> m * x
 end
 
-"""    function Δᵈ_mat(::Type{Val{2}}, s::SimplicialSets.HasDeltaSet)
+"""    function Δᵈ_mat(::Val{1}, s::SimplicialSets.HasDeltaSet)
 
 Return a function matrix encoding the dual 1-form Laplacian.
 """
-function Δᵈ(::Type{Val{1}}, s::SimplicialSets.HasDeltaSet)
+function Δᵈ(::Val{1}, s::SimplicialSets.HasDeltaSet)
   dd0 = dec_dual_derivative(0, s);
   ihs1 = dec_inv_hodge_star(1, s, GeometricHodge());
   d1 = dec_differential(1,s);
@@ -838,11 +859,11 @@ function Δᵈ(::Type{Val{1}}, s::SimplicialSets.HasDeltaSet)
   end
 end
 
-"""    dec_Δ⁻¹(::Type{Val{0}}, s::AbstractGeometricMapSeries; steps = 3, cycles = 5, alg = cg, μ = 2)
+"""    dec_Δ⁻¹(::Val{0}, s::AbstractGeometricMapSeries; steps = 3, cycles = 5, alg = cg, μ = 2)
 
 Return a function that solves the inverse Laplacian problem.
 """
-function dec_Δ⁻¹(::Type{Val{0}}, s::AbstractGeometricMapSeries; scheme::AbstractSubdivisionScheme = BinarySubdivision(), steps = 3, cycles = 5, alg = cg, μ = 2)
+function dec_Δ⁻¹(::Val{0}, s::AbstractGeometricMapSeries; scheme::AbstractSubdivisionScheme = BinarySubdivision(), steps = 3, cycles = 5, alg = cg, μ = 2)
   md = MGData(s, sd -> ∇²(0, sd), steps, scheme)
   b -> full_multigrid(b, md, cycles, alg, μ)
 end

--- a/src/FastDEC.jl
+++ b/src/FastDEC.jl
@@ -133,13 +133,13 @@ function wedge_kernel_coeffs(::Val{2}, ::Val{1}, sd::EmbeddedDeltaDualComplex3D{
 end
 
 # Grab the float type of the volumes of the complex.
-function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex1D{Bool, float_type, _p}, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
-function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex2D{Bool, float_type, _p}, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
-function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}, backend, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
+function cache_wedge(::Val{m}, ::Val{n}, sd::EmbeddedDeltaDualComplex3D{Bool, float_type, _p}, arr_cons=identity, cast_float=nothing) where {float_type,_p,m,n}
   cache_wedge(m, n, sd, float_type, arr_cons, cast_float)
 end
 
@@ -237,7 +237,7 @@ function dec_c_wedge_product(::Val{m}, ::Val{n}, α, β, wedge_cache) where {m,n
   dec_c_wedge_product!(Val(m), Val(n), res, α, β, wedge_cache[1], wedge_cache[2])
 end
 
-"""    dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {m,n}
+"""    dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing) where {m,n}
 
 Return a function that computes the wedge product between a primal `m`-form and a primal `n`-form, assuming special properties of the mesh.
 
@@ -248,43 +248,42 @@ It is assumed...
 # Arguments:
 `::Val{m}, ::Val{n}`: the degrees of the differential forms.
 `sd`: the simplicial complex.
-`backend=Val{:CPU}`: a value-type to select special backend logic, if implemented.
 `arr_cons=identity`: a constructor of the desired array type on the appropriate backend e.g. `MtlArray`.
 `cast_float=nothing`: a specific Float type to use e.g. `Float32`. Otherwise, the type of the first differential form will be used.
 """
-function dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {m,n}
+function dec_wedge_product(::Val{m}, ::Val{n}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing) where {m,n}
   error("Unsupported combination of degrees $m and $n. Ensure that their sum is not greater than the degree of the complex.")
 end
 
 dec_wedge_product(m::Int, n::Int, sd::HasDeltaSet, args...) =
   dec_wedge_product(Val(m), Val(n), sd::HasDeltaSet, args...)
 
-function dec_wedge_product(::Val{0}, ::Val{0}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
+function dec_wedge_product(::Val{0}, ::Val{0}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing)
   (f, g) -> f .* g
 end
 
-function dec_wedge_product(::Val{k}, ::Val{0}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {k}
-  wedge_cache = cache_wedge(Val(0), Val(k), sd, backend, arr_cons, cast_float)
+function dec_wedge_product(::Val{k}, ::Val{0}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing) where {k}
+  wedge_cache = cache_wedge(Val(0), Val(k), sd, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(0), Val(k), β, α, wedge_cache)
 end
 
-function dec_wedge_product(::Val{0}, ::Val{k}, sd::HasDeltaSet, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing) where {k}
-  wedge_cache = cache_wedge(Val(0), Val(k), sd, backend, arr_cons, cast_float)
+function dec_wedge_product(::Val{0}, ::Val{k}, sd::HasDeltaSet, arr_cons=identity, cast_float=nothing) where {k}
+  wedge_cache = cache_wedge(Val(0), Val(k), sd, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(0), Val(k), α, β, wedge_cache)
 end
 
-function dec_wedge_product(::Val{1}, ::Val{1}, sd::HasDeltaSet2D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Val(1), Val(1), sd, backend, arr_cons, cast_float)
+function dec_wedge_product(::Val{1}, ::Val{1}, sd::HasDeltaSet2D, arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(1), Val(1), sd, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(1), Val(1), α, β, wedge_cache)
 end
 
-function dec_wedge_product(::Val{1}, ::Val{2}, sd::HasDeltaSet3D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Val(2), Val(1), sd, backend, arr_cons, cast_float)
+function dec_wedge_product(::Val{1}, ::Val{2}, sd::HasDeltaSet3D, arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(2), Val(1), sd, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(2), Val(1), β, α, wedge_cache)
 end
 
-function dec_wedge_product(::Val{2}, ::Val{1}, sd::HasDeltaSet3D, backend=Val{:CPU}, arr_cons=identity, cast_float=nothing)
-  wedge_cache = cache_wedge(Val(2), Val(1), sd, backend, arr_cons, cast_float)
+function dec_wedge_product(::Val{2}, ::Val{1}, sd::HasDeltaSet3D, arr_cons=identity, cast_float=nothing)
+  wedge_cache = cache_wedge(Val(2), Val(1), sd, arr_cons, cast_float)
   (α, β) -> dec_c_wedge_product(Val(2), Val(1), α, β, wedge_cache)
 end
 

--- a/src/MeshOptimization.jl
+++ b/src/MeshOptimization.jl
@@ -125,7 +125,7 @@ See also: [`SimulatedAnnealing`](@ref).
 """
 function optimize_mesh!(s::HasDeltaSet2D, alg::SimulatedAnnealing, noise_generator::Function)
   @unpack_SimulatedAnnealing alg
-  int = interior(Val{0}, s)
+  int = interior(Val(0), s)
   map(1:epochs) do epoch
     # TODO: You could vectorize (with a MVN) instead of iterating over points.
     for v in (hold_boundaries ? int : vertices(s))

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -100,13 +100,6 @@ end
 
 MultigridData(g,r,p,s) = MultigridData{typeof(g),typeof(r)}(g,r,p,s)
 
-MultigridData(s::HasDeltaSet, ::UnarySubdivision, levels::Int, op::Function, steps, alg=Circumcenter()) =
-  MultigridData(s, unary_subdivision_map, levels, op, steps, alg)
-MultigridData(s::HasDeltaSet, ::BinarySubdivision, levels::Int, op::Function, steps, alg=Circumcenter()) =
-  MultigridData(s, binary_subdivision_map, levels, op, steps, alg)
-MultigridData(s::HasDeltaSet, ::CubicSubdivision, levels::Int, op::Function, steps, alg=Circumcenter()) =
-  MultigridData(s, cubic_subdivision_map, levels, op, steps, alg)
-
 # This function definition is kept for backwards compatibility.
 MGData(series::PrimalGeometricMapSeries, op::Function, s::Int, ::T) where T <: AbstractSubdivisionScheme =
   MultigridData(series, op, fill(s,length(series.meshes)))
@@ -197,13 +190,20 @@ function MultigridData(series::PrimalGeometricMapSeries, op::Function, s::Abstra
   MultigridData(ops, rs, ps, s)
 end
 
-"""    MultigridData(s::HasDeltaSet, subdivider, levels::Int, op::Function, steps, alg=Circumcenter())
+"""    MultigridData(s::HasDeltaSet, subdivider, levels::Int, op::Function, steps, alg=Circumcenter(); galerkin=false)
 
 Construct a `MultigridData` directly from a base mesh without allocating an
-entire `PrimalGeometricMapSeries`. Meshes are subdivided and dualized on demand
-so that at most two primal meshes (the current level and its subdivision) and
-one dual mesh are in memory at a time. Each dual mesh and the previous primal
-mesh are freed before proceeding to the next level.
+entire `PrimalGeometricMapSeries`. Meshes are subdivided on demand so that at
+most two primal meshes (the current level and its subdivision) are in memory at
+a time.
+
+When `galerkin=false` (default), every level is dualized and `op` is called on
+each dual mesh independently. Only one dual mesh is in memory at a time.
+
+When `galerkin=true`, only the *finest* mesh is dualized and `op` is called
+once. Coarser operators are derived algebraically via the Galerkin condition:
+`A_coarse = R * A_fine * P`. This eliminates all dualizations except one, which
+is typically the dominant cost.
 
 `subdivider` is either a subdivision scheme (e.g. `BinarySubdivision()`) or a
 subdivision map function (e.g. `binary_subdivision_map`).
@@ -213,57 +213,84 @@ subdivision map function (e.g. `binary_subdivision_map`).
 # Example
 ```julia
 md = MultigridData(s, BinarySubdivision(), 4, s -> ∇²(0, s), 3)
+md = MultigridData(s, BinarySubdivision(), 4, s -> ∇²(0, s), 3; galerkin=true)
 ```
 """
-function MultigridData(s::HasDeltaSet, subdivider::Function, levels::Int, op::Function, steps, alg=Circumcenter())
+function MultigridData(s::HasDeltaSet, subdivider::Function, levels::Int, op::Function, steps, alg=Circumcenter(); galerkin=false)
   steps_vec = steps isa AbstractVector ? steps : fill(steps, levels + 1)
 
-  # Process the coarsest mesh (s) first to determine the operator type.
-  sd = dualize(s, alg)
-  coarsest_op = op(sd)
-  sd = nothing
-
-  # Storage in coarsest-first order; reversed to finest-first at the end.
-  ops_c2f = Vector{typeof(coarsest_op)}(undef, levels + 1)
-  ops_c2f[1] = coarsest_op
-
   if levels == 0
-    return MultigridData(ops_c2f, typeof(coarsest_op)[], typeof(coarsest_op)[], steps_vec)
+    sd = dualize(s, alg)
+    only_op = op(sd)
+    return MultigridData([only_op], typeof(only_op)[], typeof(only_op)[], steps_vec)
   end
 
-  # First subdivision to determine the matrix type.
+  # --- Phase 1: Walk coarse-to-fine, subdividing on demand. ---
+  # Collect subdivision matrices into mats (finest-first).
+  # In non-galerkin mode, also dualize each mesh and stash operators into
+  # coarse_ops (coarsest-first); these are moved into the final vector later.
+
+  coarse_ops = []
+
+  if !galerkin
+    sd = dualize(s, alg)
+    push!(coarse_ops, op(sd))
+  end
+
   current_primal = s
   pgm = subdivider(current_primal)
   first_mat = as_matrix(pgm)
-  mats_c2f = Vector{typeof(first_mat)}(undef, levels)
-  mats_c2f[1] = first_mat
+  mats = Vector{typeof(first_mat)}(undef, levels)
+  mats[levels] = first_mat
   current_primal = dom(pgm)
 
-  # Each iteration: dualize current_primal → compute operator → free dual,
-  # then subdivide current_primal → extract matrix and next primal → free old primal.
   for i in 2:levels
-    sd = dualize(current_primal, alg)
-    ops_c2f[i] = op(sd)
+    if !galerkin
+      sd = dualize(current_primal, alg)
+      push!(coarse_ops, op(sd))
+    end
 
     pgm = subdivider(current_primal)
-    mats_c2f[i] = as_matrix(pgm)
+    mats[levels - i + 1] = as_matrix(pgm)
     next_primal = dom(pgm)
     current_primal = next_primal
   end
 
-  # Process the finest mesh (no further subdivision needed).
+  # current_primal is now the finest primal mesh.
+
+  # --- Phase 2: Dualize the finest mesh (required in both modes). ---
   sd = dualize(current_primal, alg)
-  ops_c2f[levels + 1] = op(sd)
+  finest_op = op(sd)
 
-  # Reverse to finest-first order expected by MultigridData.
-  reverse!(ops_c2f)
-  reverse!(mats_c2f)
-
-  ps = transpose.(mats_c2f)
+  # --- Phase 3: Assemble operators, prolongations, and restrictions. ---
+  ps = transpose.(mats)
   rs = normalize_restrictions(ps)
 
-  MultigridData(ops_c2f, rs, ps, steps_vec)
+  ops = Vector{typeof(finest_op)}(undef, levels + 1)
+  ops[1] = finest_op
+
+  if galerkin
+    # Derive coarser operators via Galerkin condition: A_coarse = R * A_fine * P.
+    for i in 1:levels
+      ops[i + 1] = rs[i] * ops[i] * ps[i]
+    end
+  else
+    # Place the coarse_ops (coarsest-first) into ops (finest-first).
+    for j in 1:levels
+      ops[levels - j + 2] = coarse_ops[j]
+    end
+  end
+
+  MultigridData(ops, rs, ps, steps_vec)
 end
+
+# Convenience: accept an AbstractSubdivisionScheme instead of a raw function.
+MultigridData(s::HasDeltaSet, ::UnarySubdivision, levels::Int, op::Function, steps, alg=Circumcenter(); kwargs...) =
+  MultigridData(s, unary_subdivision_map, levels, op, steps, alg; kwargs...)
+MultigridData(s::HasDeltaSet, ::BinarySubdivision, levels::Int, op::Function, steps, alg=Circumcenter(); kwargs...) =
+  MultigridData(s, binary_subdivision_map, levels, op, steps, alg; kwargs...)
+MultigridData(s::HasDeltaSet, ::CubicSubdivision, levels::Int, op::Function, steps, alg=Circumcenter(); kwargs...) =
+  MultigridData(s, cubic_subdivision_map, levels, op, steps, alg; kwargs...)
 
 # XXX: This function does not detect e.g. dangling edges.
 function is_simplicial_complex(s::HasDeltaSet2D)
@@ -496,7 +523,7 @@ repeated_subdivisions(k, ss, subdivider) =
 # - Input arbitrary iterative solver,
 # - Implement weighted Jacobi and maybe Gauss-Seidel,
 # - Masking for boundary condtions
-# - This could use Galerkin conditions to construct As from As[1]
+# - This could use Galerkin conditions to construct As from As[1] (see galerkin=true in MultigridData constructor)
 # - Add maxcycles and tolerances
 """
 Solve `Ax=b` on `s` with initial guess `u` using , for `cycles` V-cycles, performing `md.steps` steps of the
@@ -560,3 +587,4 @@ function _multigrid_μ_cycle(u, b, md::MultigridData, alg=cg, μ=1)
 end
 
 end
+

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -80,6 +80,24 @@ abstract type AbstractSubdivisionScheme end
 struct UnarySubdivision <: AbstractSubdivisionScheme end
 struct BinarySubdivision <: AbstractSubdivisionScheme end
 struct CubicSubdivision <: AbstractSubdivisionScheme end
+# Unary Subdivision
+#------------------
+
+function propagate_points(::UnarySubdivision, topo::MeshTopology,
+    coarse_points::AbstractVector)
+  copy(coarse_points)
+end
+
+function refine(::UnarySubdivision, topo::MeshTopology)
+  deepcopy(topo)
+end
+
+function subdivision_matrix(::UnarySubdivision, topo::MeshTopology)
+  I(topo.nv)
+end
+
+unary_subdivision_topo(topo::MeshTopology) =
+  (refine(UnarySubdivision(), topo), subdivision_matrix(UnarySubdivision(), topo))
 
 # Binary Subdivision
 #-------------------
@@ -91,7 +109,7 @@ Interpolate vertex positions for binary subdivision.
 Original vertices are copied; midpoints are averaged from edge endpoints.
 """
 function propagate_points(::BinarySubdivision, topo::MeshTopology,
-                          coarse_points::AbstractVector)
+    coarse_points::AbstractVector)
   nv_c = topo.nv
   nv_f = nv_c + topo.ne
   fine_points = similar(coarse_points, nv_f)
@@ -219,7 +237,7 @@ Original vertices are copied; edge points at ⅓/⅔ positions and
 triangle centroids are computed from connectivity.
 """
 function propagate_points(::CubicSubdivision, topo::MeshTopology,
-                          coarse_points::AbstractVector)
+    coarse_points::AbstractVector)
   nv_c = topo.nv
   ne_c = topo.ne
   nv_f = nv_c + 2 * ne_c + topo.ntri
@@ -750,8 +768,8 @@ function _build_multigrid(mode::AbstractMultigridMode, s::HasDeltaSet2D,
 
   # Phase 2: Coarse-to-fine subdivision walk.
   # First step bootstraps concrete types for ps/rs.
-  points = propagate_points(scheme, topo, points)
   mat = subdivision_matrix(scheme, topo)
+  points = propagate_points(scheme, topo, points)
   topo = refine(scheme, topo)
   first_p = transpose(mat)
   first_r = make_restriction(first_p)

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -683,13 +683,6 @@ function MultigridData(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme,
   _build_multigrid(mode, s, scheme, levels, op, steps, alg)
 end
 
-# Fallback for HasDeltaSet (1D) — delegates to function-based path.
-function MultigridData(s::HasDeltaSet, scheme::AbstractSubdivisionScheme,
-                       levels::Int, op::Function, steps; alg=Circumcenter(),
-                       mode::AbstractMultigridMode=DirectMode())
-  MultigridData(s, x -> subdivision_map(x, scheme), levels, op, steps, alg)
-end
-
 # _build_multigrid
 #-----------------
 
@@ -730,7 +723,7 @@ function _finalize_ops(::GalerkinMode, _, S, topo, points, ps, rs, levels, op, a
   finest_op = op(dualize(topo_to_mesh(S, topo, points), alg))
   ops = Vector{typeof(finest_op)}(undef, levels + 1)
   ops[1] = finest_op
-  for i in 1:levels
+  @inbounds for i in 1:levels
     ops[i + 1] = rs[i] * ops[i] * ps[i]
   end
   ops

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -100,6 +100,13 @@ end
 
 MultigridData(g,r,p,s) = MultigridData{typeof(g),typeof(r)}(g,r,p,s)
 
+MultigridData(s::HasDeltaSet, ::UnarySubdivision, levels::Int, op::Function, steps, alg=Circumcenter()) =
+  MultigridData(s, unary_subdivision_map, levels, op, steps, alg)
+MultigridData(s::HasDeltaSet, ::BinarySubdivision, levels::Int, op::Function, steps, alg=Circumcenter()) =
+  MultigridData(s, binary_subdivision_map, levels, op, steps, alg)
+MultigridData(s::HasDeltaSet, ::CubicSubdivision, levels::Int, op::Function, steps, alg=Circumcenter()) =
+  MultigridData(s, cubic_subdivision_map, levels, op, steps, alg)
+
 # This function definition is kept for backwards compatibility.
 MGData(series::PrimalGeometricMapSeries, op::Function, s::Int, ::T) where T <: AbstractSubdivisionScheme =
   MultigridData(series, op, fill(s,length(series.meshes)))
@@ -188,6 +195,74 @@ function MultigridData(series::PrimalGeometricMapSeries, op::Function, s::Abstra
   ps = transpose.(matrices(series))
   rs = normalize_restrictions(ps)
   MultigridData(ops, rs, ps, s)
+end
+
+"""    MultigridData(s::HasDeltaSet, subdivider, levels::Int, op::Function, steps, alg=Circumcenter())
+
+Construct a `MultigridData` directly from a base mesh without allocating an
+entire `PrimalGeometricMapSeries`. Meshes are subdivided and dualized on demand
+so that at most two primal meshes (the current level and its subdivision) and
+one dual mesh are in memory at a time. Each dual mesh and the previous primal
+mesh are freed before proceeding to the next level.
+
+`subdivider` is either a subdivision scheme (e.g. `BinarySubdivision()`) or a
+subdivision map function (e.g. `binary_subdivision_map`).
+
+`steps` may be an `Int` (constant across all grids) or an `AbstractVector`.
+
+# Example
+```julia
+md = MultigridData(s, BinarySubdivision(), 4, s -> ∇²(0, s), 3)
+```
+"""
+function MultigridData(s::HasDeltaSet, subdivider::Function, levels::Int, op::Function, steps, alg=Circumcenter())
+  steps_vec = steps isa AbstractVector ? steps : fill(steps, levels + 1)
+
+  # Process the coarsest mesh (s) first to determine the operator type.
+  sd = dualize(s, alg)
+  coarsest_op = op(sd)
+  sd = nothing
+
+  # Storage in coarsest-first order; reversed to finest-first at the end.
+  ops_c2f = Vector{typeof(coarsest_op)}(undef, levels + 1)
+  ops_c2f[1] = coarsest_op
+
+  if levels == 0
+    return MultigridData(ops_c2f, typeof(coarsest_op)[], typeof(coarsest_op)[], steps_vec)
+  end
+
+  # First subdivision to determine the matrix type.
+  current_primal = s
+  pgm = subdivider(current_primal)
+  first_mat = as_matrix(pgm)
+  mats_c2f = Vector{typeof(first_mat)}(undef, levels)
+  mats_c2f[1] = first_mat
+  current_primal = dom(pgm)
+
+  # Each iteration: dualize current_primal → compute operator → free dual,
+  # then subdivide current_primal → extract matrix and next primal → free old primal.
+  for i in 2:levels
+    sd = dualize(current_primal, alg)
+    ops_c2f[i] = op(sd)
+
+    pgm = subdivider(current_primal)
+    mats_c2f[i] = as_matrix(pgm)
+    next_primal = dom(pgm)
+    current_primal = next_primal
+  end
+
+  # Process the finest mesh (no further subdivision needed).
+  sd = dualize(current_primal, alg)
+  ops_c2f[levels + 1] = op(sd)
+
+  # Reverse to finest-first order expected by MultigridData.
+  reverse!(ops_c2f)
+  reverse!(mats_c2f)
+
+  ps = transpose.(mats_c2f)
+  rs = normalize_restrictions(ps)
+
+  MultigridData(ops_c2f, rs, ps, steps_vec)
 end
 
 # XXX: This function does not detect e.g. dangling edges.

--- a/src/Multigrid.jl
+++ b/src/Multigrid.jl
@@ -1,20 +1,70 @@
 module Multigrid
 
 using CombinatorialSpaces
-using LinearAlgebra: I, Diagonal
-using Krylov, Catlab, SparseArrays, StaticArrays
+using LinearAlgebra: I, Diagonal, Transpose
+using Krylov, Catlab, SparseArrays
 using ..SimplicialSets
 import Catlab: dom, codom
 
 export multigrid_vcycles, multigrid_wcycles, full_multigrid,
-  repeated_subdivisions, binary_subdivision, binary_subdivision_map, dom, codom,
+  repeated_subdivisions, repeated_subdivision_maps,
+  binary_subdivision, binary_subdivision_map, dom, codom,
   as_matrix, MultigridData, MGData, AbstractGeometricMapSeries,
   PrimalGeometricMapSeries, finest_mesh, meshes, matrices, cubic_subdivision,
   cubic_subdivision_map, AbstractSubdivisionScheme, BinarySubdivision,
-  CubicSubdivision
+  CubicSubdivision, MeshTopology, subdivision, subdivision_map, subdivision_matrix,
+  refine, propagate_points,
+  AbstractMultigridMode, DirectMode, GalerkinMode,
+  binary_subdivision_topo, cubic_subdivision_topo
 
-# Types, Structs, Constructors, Getters & Setters, and Dispatch Control
-#----------------------------------------------------------------------
+# MeshTopology
+#-------------
+
+"""    struct MeshTopology
+
+Boundary maps of a simplicial 2-complex as plain arrays.
+"""
+struct MeshTopology
+  nv::Int
+  ne::Int
+  ntri::Int
+  ∂v0::Vector{Int}
+  ∂v1::Vector{Int}
+  ∂e0::Vector{Int}
+  ∂e1::Vector{Int}
+  ∂e2::Vector{Int}
+end
+
+MeshTopology(s::EmbeddedDeltaSet1D) =
+  MeshTopology(nv(s), ne(s), 0, s[:∂v0], s[:∂v1], Int[], Int[], Int[])
+
+MeshTopology(s::EmbeddedDeltaSet2D) =
+  MeshTopology(nv(s), ne(s), ntriangles(s), s[:∂v0], s[:∂v1], s[:∂e0], s[:∂e1], s[:∂e2])
+
+"""
+    topo_to_mesh(::Type{S}, topo::MeshTopology, points) -> S
+
+Reconstitute an `EmbeddedDeltaSet` from a `MeshTopology` and point data.
+"""
+function topo_to_mesh(::Type{S}, topo::MeshTopology,
+                      points) where S <: Union{EmbeddedDeltaSet1D, EmbeddedDeltaSet2D}
+  sd = S()
+  add_vertices!(sd, topo.nv)
+  sd[1:topo.nv, :point] = points
+  add_parts!(sd, :E, topo.ne)
+  sd[1:topo.ne, :∂v0] = topo.∂v0
+  sd[1:topo.ne, :∂v1] = topo.∂v1
+  if S <: EmbeddedDeltaSet2D && topo.ntri > 0
+    add_parts!(sd, :Tri, topo.ntri)
+    sd[1:topo.ntri, :∂e0] = topo.∂e0
+    sd[1:topo.ntri, :∂e1] = topo.∂e1
+    sd[1:topo.ntri, :∂e2] = topo.∂e2
+  end
+  sd
+end
+
+# Types
+#------
 
 struct PrimalGeometricMap{D,M}
   domain::D
@@ -27,40 +77,421 @@ codom(f::PrimalGeometricMap) = f.codomain
 as_matrix(f::PrimalGeometricMap) = f.matrix
 
 abstract type AbstractSubdivisionScheme end
-
 struct UnarySubdivision <: AbstractSubdivisionScheme end
 struct BinarySubdivision <: AbstractSubdivisionScheme end
 struct CubicSubdivision <: AbstractSubdivisionScheme end
 
-subdivision(s::EmbeddedDeltaSet2D, ::UnarySubdivision) = unary_subdivision(s)
-subdivision(s::EmbeddedDeltaSet2D, ::BinarySubdivision) = binary_subdivision(s)
-subdivision(s::EmbeddedDeltaSet2D, ::CubicSubdivision) = cubic_subdivision(s)
-subdivision(s::EmbeddedDeltaSet2D) = binary_subdivision(s, BinarySubdivision)
+# Binary Subdivision
+#-------------------
 
-unary_subdivision_map(pgm::PrimalGeometricMap) = unary_subdivision_map(dom(pgm))
-binary_subdivision_map(pgm::PrimalGeometricMap) = binary_subdivision_map(dom(pgm))
-cubic_subdivision_map(pgm::PrimalGeometricMap) = cubic_subdivision_map(dom(pgm))
-
-repeated_subdivisions(k, ss, ::UnarySubdivision) = repeated_subdivisions(k, ss, unary_subdivision_map)
-repeated_subdivisions(k, ss, ::BinarySubdivision) = repeated_subdivisions(k, ss, binary_subdivision_map)
-repeated_subdivisions(k, ss, ::CubicSubdivision) = repeated_subdivisions(k, ss, cubic_subdivision_map)
-repeated_subdivisions(k, ss) = repeated_subdivisions(k, ss, BinarySubdivision)
-
-# Different means of representing a series of complexes with maps between them should sub-type this abstract type.
-# Those concrete types should then provide a constructor for `MultigridData`.
-"""    abstract type AbstractGeometricMapSeries end
-
-Organizes the mesh data that results from mesh refinement through a subdivision method.
-
-See also: [`PrimalGeometricMapSeries`](@ref).
 """
+    propagate_points(::BinarySubdivision, topo, coarse_points) -> fine_points
+
+Interpolate vertex positions for binary subdivision.
+Original vertices are copied; midpoints are averaged from edge endpoints.
+"""
+function propagate_points(::BinarySubdivision, topo::MeshTopology,
+                          coarse_points::AbstractVector)
+  nv_c = topo.nv
+  nv_f = nv_c + topo.ne
+  fine_points = similar(coarse_points, nv_f)
+  copyto!(fine_points, 1, coarse_points, 1, nv_c)
+  @inbounds for e in 1:topo.ne
+    fine_points[nv_c + e] =
+      (coarse_points[topo.∂v0[e]] + coarse_points[topo.∂v1[e]]) / 2
+  end
+  fine_points
+end
+
+"""
+    refine(::BinarySubdivision, topo) -> MeshTopology
+
+Binary (medial) topology refinement: split each edge at its midpoint,
+subdivide each triangle into 4.  No subdivision matrix is constructed.
+"""
+function refine(::BinarySubdivision, topo::MeshTopology)
+  nv_c, ne_c, ntri_c = topo.nv, topo.ne, topo.ntri
+  nv_f   = nv_c + ne_c
+  ne_f   = 2 * ne_c + 3 * ntri_c
+  ntri_f = 4 * ntri_c
+
+  # --- Edge boundary maps ---
+  ∂v0_f = Vector{Int}(undef, ne_f)
+  ∂v1_f = Vector{Int}(undef, ne_f)
+
+  @inbounds for e in 1:ne_c
+    m = nv_c + e
+    ∂v0_f[2 * e - 1] = m;          ∂v1_f[2 * e - 1] = topo.∂v0[e]
+    ∂v0_f[2 * e]     = m;          ∂v1_f[2 * e]     = topo.∂v1[e]
+  end
+
+  # --- Triangle boundary maps ---
+  #       v2
+  #      /  \
+  #    m1 -- m0
+  #   /  \  /  \
+  # v0 -- m2 -- v1
+  ∂e0_f = Vector{Int}(undef, ntri_f)
+  ∂e1_f = Vector{Int}(undef, ntri_f)
+  ∂e2_f = Vector{Int}(undef, ntri_f)
+
+  @inbounds for t in 1:ntri_c
+    e0, e1, e2 = topo.∂e0[t], topo.∂e1[t], topo.∂e2[t]
+    m0, m1, m2 = e0 + nv_c, e1 + nv_c, e2 + nv_c
+
+    # Interior edges connecting the three midpoints.
+    m0_m1 = 2 * ne_c + 3 * t - 2
+    m1_m2 = 2 * ne_c + 3 * t - 1
+    m0_m2 = 2 * ne_c + 3 * t
+
+    ∂v0_f[m0_m1] = m1;  ∂v1_f[m0_m1] = m0
+    ∂v0_f[m1_m2] = m2;  ∂v1_f[m1_m2] = m1
+    ∂v0_f[m0_m2] = m2;  ∂v1_f[m0_m2] = m0
+
+    # Split-edge references.
+    m0_v1  = 2 * e0;      v2_m0 = 2 * e0 - 1
+    m1_v0  = 2 * e1;      v2_m1 = 2 * e1 - 1
+    m2_v0  = 2 * e2;      v1_m2 = 2 * e2 - 1
+
+    # 4 child triangles.
+    b = 4 * t - 3
+    ∂e0_f[b]     = m1_m2;  ∂e1_f[b]     = m0_m2;  ∂e2_f[b]     = m0_m1
+    ∂e0_f[b + 1] = m1_m2;  ∂e1_f[b + 1] = m2_v0;  ∂e2_f[b + 1] = m1_v0
+    ∂e0_f[b + 2] = m0_m2;  ∂e1_f[b + 2] = v1_m2;  ∂e2_f[b + 2] = m0_v1
+    ∂e0_f[b + 3] = m0_m1;  ∂e1_f[b + 3] = v2_m1;  ∂e2_f[b + 3] = v2_m0
+  end
+
+  MeshTopology(nv_f, ne_f, ntri_f, ∂v0_f, ∂v1_f, ∂e0_f, ∂e1_f, ∂e2_f)
+end
+
+"""
+    subdivision_matrix(::BinarySubdivision, topo) -> SparseMatrixCSC
+
+Build the binary subdivision matrix (nv_coarse × nv_fine) in direct CSC
+format.  Identity block for original vertices, ½/½ averages for midpoints.
+"""
+function subdivision_matrix(::BinarySubdivision, topo::MeshTopology)
+  nv_c, ne_c = topo.nv, topo.ne
+  nv_f = nv_c + ne_c
+
+  nnz = nv_c + 2 * ne_c
+  colptr = Vector{Int32}(undef, nv_f + 1)
+  rowval = Vector{Int32}(undef, nnz)
+  nzval  = Vector{Float64}(undef, nnz)
+
+  @inbounds for i in 1:nv_c
+    colptr[i] = Int32(i)
+    rowval[i] = Int32(i)
+    nzval[i]  = 1.0
+  end
+  @inbounds for e in 1:ne_c
+    k = nv_c + 2 * e - 1
+    colptr[nv_c + e] = Int32(k)
+    r0 = Int32(topo.∂v0[e])
+    r1 = Int32(topo.∂v1[e])
+    if r0 > r1
+      r0, r1 = r1, r0
+    end
+    rowval[k]     = r0;  nzval[k]     = 0.5
+    rowval[k + 1] = r1;  nzval[k + 1] = 0.5
+  end
+  colptr[nv_f + 1] = Int32(nnz + 1)
+
+  SparseMatrixCSC(nv_c, nv_f, colptr, rowval, nzval)
+end
+
+"""
+    binary_subdivision_topo(topo::MeshTopology) -> (refined::MeshTopology, mat)
+
+Binary subdivision returning both topology and matrix.
+"""
+binary_subdivision_topo(topo::MeshTopology) =
+  (refine(BinarySubdivision(), topo), subdivision_matrix(BinarySubdivision(), topo))
+
+# Cubic Subdivision
+#------------------
+
+"""
+    propagate_points(::CubicSubdivision, topo, coarse_points) -> fine_points
+
+Interpolate vertex positions for cubic subdivision.
+Original vertices are copied; edge points at ⅓/⅔ positions and
+triangle centroids are computed from connectivity.
+"""
+function propagate_points(::CubicSubdivision, topo::MeshTopology,
+                          coarse_points::AbstractVector)
+  nv_c = topo.nv
+  ne_c = topo.ne
+  nv_f = nv_c + 2 * ne_c + topo.ntri
+  fine_points = similar(coarse_points, nv_f)
+  copyto!(fine_points, 1, coarse_points, 1, nv_c)
+  @inbounds for e in 1:ne_c
+    p0 = coarse_points[topo.∂v0[e]]
+    p1 = coarse_points[topo.∂v1[e]]
+    fine_points[nv_c + 2 * e - 1] = (2 * p0 + p1) / 3
+    fine_points[nv_c + 2 * e]     = (p0 + 2 * p1) / 3
+  end
+  @inbounds for t in 1:topo.ntri
+    pA = coarse_points[topo.∂v1[topo.∂e1[t]]]
+    pB = coarse_points[topo.∂v1[topo.∂e0[t]]]
+    pC = coarse_points[topo.∂v0[topo.∂e0[t]]]
+    fine_points[nv_c + 2 * ne_c + t] = (pA + pB + pC) / 3
+  end
+  fine_points
+end
+
+"""
+    refine(::CubicSubdivision, topo) -> MeshTopology
+
+Cubic topology refinement: two interior points per edge plus a centroid per
+triangle, subdividing each triangle into 9.  No subdivision matrix is constructed.
+"""
+function refine(::CubicSubdivision, topo::MeshTopology)
+  nv_c, ne_c, ntri_c = topo.nv, topo.ne, topo.ntri
+  nv_f   = nv_c + 2 * ne_c + ntri_c
+  ne_f   = 3 * ne_c + 9 * ntri_c
+  ntri_f = 9 * ntri_c
+
+  # --- Edge boundary maps ---
+  #  v0 -> m0 -> m1 -> v1  (3 child edges per original)
+  ∂v0_f = Vector{Int}(undef, ne_f)
+  ∂v1_f = Vector{Int}(undef, ne_f)
+
+  @inbounds for e in 1:ne_c
+    m0  = nv_c + 2 * e - 1
+    m1  = nv_c + 2 * e
+    v0e = topo.∂v0[e]
+    v1e = topo.∂v1[e]
+    ∂v0_f[3 * e - 2] = m0;   ∂v1_f[3 * e - 2] = v0e
+    ∂v0_f[3 * e - 1] = m1;   ∂v1_f[3 * e - 1] = m0
+    ∂v0_f[3 * e]     = v1e;  ∂v1_f[3 * e]     = m1
+  end
+
+  # --- Triangle boundary maps ---
+  #          030
+  #         ^  v
+  #       021 > 120
+  #      ^  ^  ^  v
+  #    012< 111  >210
+  #   ^  ^  ^  ^  ^  v
+  # 003 >102  >201  >300
+  ∂e0_f = Vector{Int}(undef, ntri_f)
+  ∂e1_f = Vector{Int}(undef, ntri_f)
+  ∂e2_f = Vector{Int}(undef, ntri_f)
+
+  @inbounds for t in 1:ntri_c
+    e0, e1, e2 = topo.∂e0[t], topo.∂e1[t], topo.∂e2[t]
+
+    # Interior vertex indices (barycentric coordinate naming).
+    m012 = 2 * e0 + nv_c - 1;  m021 = 2 * e0 + nv_c
+    m102 = 2 * e1 + nv_c - 1;  m201 = 2 * e1 + nv_c
+    m120 = 2 * e2 + nv_c - 1;  m210 = 2 * e2 + nv_c
+    m111 = nv_c + 2 * ne_c + t
+
+    # 9 interior edges.
+    be = 3 * ne_c + 9 * t - 8
+    ∂v0_f[be]     = m210;  ∂v1_f[be]     = m201
+    ∂v0_f[be + 1] = m111;  ∂v1_f[be + 1] = m201
+    ∂v0_f[be + 2] = m111;  ∂v1_f[be + 2] = m102
+    ∂v0_f[be + 3] = m012;  ∂v1_f[be + 3] = m102
+    ∂v0_f[be + 4] = m012;  ∂v1_f[be + 4] = m111
+    ∂v0_f[be + 5] = m021;  ∂v1_f[be + 5] = m111
+    ∂v0_f[be + 6] = m210;  ∂v1_f[be + 6] = m111
+    ∂v0_f[be + 7] = m120;  ∂v1_f[be + 7] = m111
+    ∂v0_f[be + 8] = m120;  ∂v1_f[be + 8] = m021
+
+    # Named edge references for triangle wiring.
+    m201_m210 = be;      m201_m111 = be + 1;  m102_m111 = be + 2
+    m102_m012 = be + 3;  m111_m012 = be + 4;  m111_m021 = be + 5
+    m111_m210 = be + 6;  m111_m120 = be + 7;  m021_m120 = be + 8
+
+    m021_v030 = 3 * e0;      m201_v300 = 3 * e1;      m210_v300 = 3 * e2
+    m012_m021 = 3 * e0 - 1;  m102_m201 = 3 * e1 - 1;  m120_m210 = 3 * e2 - 1
+    v003_m012 = 3 * e0 - 2;  v003_m102 = 3 * e1 - 2;  v030_m120 = 3 * e2 - 2
+
+    # 9 child triangles.
+    bt = 9 * t - 8
+    ∂e0_f[bt]     = m210_v300;  ∂e1_f[bt]     = m201_v300;  ∂e2_f[bt]     = m201_m210
+    ∂e0_f[bt + 1] = m111_m210;  ∂e1_f[bt + 1] = m201_m210;  ∂e2_f[bt + 1] = m201_m111
+    ∂e0_f[bt + 2] = m201_m111;  ∂e1_f[bt + 2] = m102_m111;  ∂e2_f[bt + 2] = m102_m201
+    ∂e0_f[bt + 3] = m111_m012;  ∂e1_f[bt + 3] = m102_m012;  ∂e2_f[bt + 3] = m102_m111
+    ∂e0_f[bt + 4] = m102_m012;  ∂e1_f[bt + 4] = v003_m012;  ∂e2_f[bt + 4] = v003_m102
+    ∂e0_f[bt + 5] = m120_m210;  ∂e1_f[bt + 5] = m111_m210;  ∂e2_f[bt + 5] = m111_m120
+    ∂e0_f[bt + 6] = m021_m120;  ∂e1_f[bt + 6] = m111_m120;  ∂e2_f[bt + 6] = m111_m021
+    ∂e0_f[bt + 7] = m012_m021;  ∂e1_f[bt + 7] = m111_m021;  ∂e2_f[bt + 7] = m111_m012
+    ∂e0_f[bt + 8] = v030_m120;  ∂e1_f[bt + 8] = m021_m120;  ∂e2_f[bt + 8] = m021_v030
+  end
+
+  MeshTopology(nv_f, ne_f, ntri_f, ∂v0_f, ∂v1_f, ∂e0_f, ∂e1_f, ∂e2_f)
+end
+
+"""
+    subdivision_matrix(::CubicSubdivision, topo) -> SparseMatrixCSC
+
+Build the cubic subdivision matrix (nv_coarse × nv_fine) in direct CSC
+format.  Identity block for original vertices, ⅓/⅔ weights for edge
+points, equal weights for centroids.
+"""
+function subdivision_matrix(::CubicSubdivision, topo::MeshTopology)
+  nv_c, ne_c, ntri_c = topo.nv, topo.ne, topo.ntri
+  nv_f = nv_c + 2 * ne_c + ntri_c
+
+  nnz = nv_c + 4 * ne_c + 3 * ntri_c
+  colptr = Vector{Int32}(undef, nv_f + 1)
+  rowval = Vector{Int32}(undef, nnz)
+  nzval  = Vector{Float64}(undef, nnz)
+
+  @inbounds for i in 1:nv_c
+    colptr[i] = Int32(i)
+    rowval[i] = Int32(i)
+    nzval[i]  = 1.0
+  end
+
+  # Two interior points per edge.
+  @inbounds for e in 1:ne_c
+    r0 = Int32(topo.∂v0[e])
+    r1 = Int32(topo.∂v1[e])
+    lo, hi = r0 < r1 ? (r0, r1) : (r1, r0)
+    w_lo_third = r0 < r1 ? 2.0 / 3 : 1.0 / 3
+    w_hi_third = r0 < r1 ? 1.0 / 3 : 2.0 / 3
+
+    # ⅓ point column.
+    k1 = nv_c + 4 * e - 3
+    colptr[nv_c + 2 * e - 1] = Int32(k1)
+    rowval[k1]     = lo;  nzval[k1]     = w_lo_third
+    rowval[k1 + 1] = hi;  nzval[k1 + 1] = w_hi_third
+
+    # ⅔ point column.
+    k2 = nv_c + 4 * e - 1
+    colptr[nv_c + 2 * e] = Int32(k2)
+    rowval[k2]     = lo;  nzval[k2]     = w_hi_third
+    rowval[k2 + 1] = hi;  nzval[k2 + 1] = w_lo_third
+  end
+
+  # Centroid columns.
+  @inbounds for t in 1:ntri_c
+    k = nv_c + 4 * ne_c + 3 * t - 2
+    colptr[nv_c + 2 * ne_c + t] = Int32(k)
+    vA = Int32(topo.∂v1[topo.∂e1[t]])
+    vB = Int32(topo.∂v1[topo.∂e0[t]])
+    vC = Int32(topo.∂v0[topo.∂e0[t]])
+    vA > vB && ((vA, vB) = (vB, vA))
+    vB > vC && ((vB, vC) = (vC, vB))
+    vA > vB && ((vA, vB) = (vB, vA))
+    rowval[k]     = vA;  nzval[k]     = 1.0 / 3
+    rowval[k + 1] = vB;  nzval[k + 1] = 1.0 / 3
+    rowval[k + 2] = vC;  nzval[k + 2] = 1.0 / 3
+  end
+
+  colptr[nv_f + 1] = Int32(nnz + 1)
+  SparseMatrixCSC(nv_c, nv_f, colptr, rowval, nzval)
+end
+
+"""
+    cubic_subdivision_topo(topo::MeshTopology) -> (refined::MeshTopology, mat)
+
+Cubic subdivision returning both topology and matrix.
+"""
+cubic_subdivision_topo(topo::MeshTopology) =
+  (refine(CubicSubdivision(), topo), subdivision_matrix(CubicSubdivision(), topo))
+
+"""
+    propagate_points(mat::SparseMatrixCSC, coarse_points) -> fine_points
+
+Interpolate via column-wise SpMV on the subdivision matrix.  Exported for
+external callers that have a matrix but no scheme type; all internal paths
+use the scheme-dispatched methods above.
+"""
+function propagate_points(mat::SparseMatrixCSC, coarse_points::AbstractVector)
+  nv_fine = size(mat, 2)
+  fine_points = similar(coarse_points, nv_fine)
+  rv = rowvals(mat)
+  nz = nonzeros(mat)
+  @inbounds for j in 1:nv_fine
+    pt = zero(eltype(coarse_points))
+    for idx in nzrange(mat, j)
+      pt += nz[idx] * coarse_points[rv[idx]]
+    end
+    fine_points[j] = pt
+  end
+  fine_points
+end
+
+# ACSet Subdivision Interface
+#----------------------------
+
+"""
+    subdivision(s, scheme) -> EmbeddedDeltaSet
+
+Subdivide a mesh.  Only refines topology and propagates points — no
+subdivision matrix is constructed.
+"""
+function subdivision(s::Union{EmbeddedDeltaSet1D, EmbeddedDeltaSet2D},
+                     scheme::AbstractSubdivisionScheme)
+  topo = MeshTopology(s)
+  points = propagate_points(scheme, topo, s[:point])
+  topo_to_mesh(typeof(s), refine(scheme, topo), points)
+end
+
+subdivision(s::EmbeddedDeltaSet2D, ::UnarySubdivision) = copy(s)
+subdivision(s::EmbeddedDeltaSet2D) = subdivision(s, BinarySubdivision())
+
+"""
+    subdivision_map(s, scheme) -> PrimalGeometricMap
+
+Subdivide and return the geometric map (mesh + subdivision matrix).
+"""
+function subdivision_map(s::Union{EmbeddedDeltaSet1D, EmbeddedDeltaSet2D},
+                         scheme::AbstractSubdivisionScheme)
+  topo = MeshTopology(s)
+  mat = subdivision_matrix(scheme, topo)
+  points = propagate_points(scheme, topo, s[:point])
+  sd = topo_to_mesh(typeof(s), refine(scheme, topo), points)
+  PrimalGeometricMap(sd, s, mat)
+end
+
+function subdivision_map(s::Union{EmbeddedDeltaSet1D, EmbeddedDeltaSet2D}, ::UnarySubdivision)
+  PrimalGeometricMap(copy(s), s, I(nv(s)))
+end
+
+subdivision_map(pgm::PrimalGeometricMap, scheme::AbstractSubdivisionScheme) =
+  subdivision_map(dom(pgm), scheme)
+
+# Backward-compatible named aliases.
+binary_subdivision(s) = subdivision(s, BinarySubdivision())
+cubic_subdivision(s)  = subdivision(s, CubicSubdivision())
+unary_subdivision(s)  = subdivision(s, UnarySubdivision())
+
+binary_subdivision_map(s) = subdivision_map(s, BinarySubdivision())
+cubic_subdivision_map(s)  = subdivision_map(s, CubicSubdivision())
+unary_subdivision_map(s)  = subdivision_map(s, UnarySubdivision())
+
+# Repeated Subdivisions and Map Series
+#-------------------------------------
+
+"""
+    repeated_subdivisions(k, ss, scheme) -> Vector{EmbeddedDeltaSet}
+
+Apply `k` subdivisions.  Returns meshes only — no subdivision matrices
+are constructed.
+"""
+repeated_subdivisions(k, ss, scheme::AbstractSubdivisionScheme) =
+  accumulate((x,_) -> subdivision(x, scheme), 1:k; init=ss)
+repeated_subdivisions(k, ss) = repeated_subdivisions(k, ss, BinarySubdivision())
+
+"""
+    repeated_subdivision_maps(k, ss, subdivider) -> Vector{PrimalGeometricMap}
+
+Apply `k` subdivisions via `subdivider`, returning geometric maps (meshes +
+matrices).  Used by `PrimalGeometricMapSeries`.
+"""
+repeated_subdivision_maps(k, ss, scheme::AbstractSubdivisionScheme) =
+  repeated_subdivision_maps(k, ss, x -> subdivision_map(x, scheme))
+repeated_subdivision_maps(k, ss, subdivider::Function) =
+  accumulate((x,_) -> subdivider(x), 1:k; init=ss)
+
 abstract type AbstractGeometricMapSeries end
 
-"""    struct PrimalGeometricMapSeries{D<:HasDeltaSet, M<:AbstractMatrix} <: AbstractGeometricMapSeries
-Organize a series of dual complexes and maps between primal vertices between them.
-
-See also: [`AbstractGeometricMapSeries`](@ref).
-"""
 struct PrimalGeometricMapSeries{D<:HasDeltaSet, M<:AbstractMatrix} <: AbstractGeometricMapSeries
   meshes::AbstractVector{D}
   matrices::AbstractVector{M}
@@ -68,120 +499,109 @@ end
 
 meshes(series::PrimalGeometricMapSeries) = series.meshes
 matrices(series::PrimalGeometricMapSeries) = series.matrices
-
-PrimalGeometricMapSeries(s::HasDeltaSet, ::UnarySubdivision, levels::Int, alg = Circumcenter()) =
-  PrimalGeometricMapSeries(s, unary_subdivision_map, levels, alg)
-PrimalGeometricMapSeries(s::HasDeltaSet, ::BinarySubdivision, levels::Int, alg = Circumcenter()) =
-  PrimalGeometricMapSeries(s, binary_subdivision_map, levels, alg)
-PrimalGeometricMapSeries(s::HasDeltaSet, ::CubicSubdivision, levels::Int, alg = Circumcenter()) =
-  PrimalGeometricMapSeries(s, cubic_subdivision_map, levels, alg)
-PrimalGeometricMapSeries(s::HasDeltaSet, levels::Int, alg = Circumcenter()) =
-  PrimalGeometricMapSeries(s, binary_subdivision_map, levels, alg)
-
-"""    finest_mesh(series::PrimalGeometricMapSeries)
-
-Return the mesh in a `PrimalGeometricMapSeries` with the highest resolution.
-"""
 finest_mesh(series::PrimalGeometricMapSeries) = first(series.meshes)
 
-"""    struct MultigridData{Gv,Mv}
+PrimalGeometricMapSeries(s::HasDeltaSet, scheme::AbstractSubdivisionScheme, levels::Int, alg=Circumcenter()) =
+  PrimalGeometricMapSeries(s, x -> subdivision_map(x, scheme), levels, alg)
+PrimalGeometricMapSeries(s::HasDeltaSet, levels::Int, alg=Circumcenter()) =
+  PrimalGeometricMapSeries(s, BinarySubdivision(), levels, alg)
 
-Contains the data required for multigrid methods. If there are
-`n` grids, there are `n-1` restrictions and prolongations and `n`
-step radii. This structure does not contain the solution `u` or
-the right-hand side `b` because those would have to mutate.
-"""
-struct MultigridData{Gv,Mv}
-  operators::Gv
-  restrictions::Mv
-  prolongations::Mv
-  steps::Vector{Int}
-end
-
-MultigridData(g,r,p,s) = MultigridData{typeof(g),typeof(r)}(g,r,p,s)
-
-# This function definition is kept for backwards compatibility.
-MGData(series::PrimalGeometricMapSeries, op::Function, s::Int, ::T) where T <: AbstractSubdivisionScheme =
-  MultigridData(series, op, fill(s,length(series.meshes)))
-
-MGData(series::PrimalGeometricMapSeries, op::Function, s::Int) =
-  MultigridData(series, op, fill(s,length(series.meshes)))
-
-"""    MultigridData(g,r,p,s::Int)
-
-Construct a `MultigridData` with a constant step radius on each grid.
-"""
-MultigridData(g,r,p,s::Int) = MultigridData(g,r,p,fill(s,length(g)))
-
-"""    function car(md::MultigridData)
-
-Get the leading grid, restriction, prolongation, and step radius.
-"""
-function car(md::MultigridData)
-  first_or_null(x) = isempty(x) ? nothing : first(x)
-  first_or_null.([md.operators, md.restrictions, md.prolongations, md.steps])
-end
-
-"""    cdr(md::MultigridData)
-
-Remove the leading grid, restriction, prolongation, and step radius.
-"""
-cdr(md::MultigridData) =
-  length(md) > 1 ?
-    MultigridData(md.operators[2:end],md.restrictions[2:end],md.prolongations[2:end],md.steps[2:end]) :
-    error("Not enough grids remaining in $md to take the cdr.")
-
-"""    Base.length(md::MultigridData)
-
-The length of a `MultigridData` is its number of grids.
-"""
-Base.length(md::MultigridData) = length(md.operators)
-
-"""    function PrimalGeometricMapSeries(s::HasDeltaSet, subdivider::Function, levels::Int, alg = Circumcenter())
-
-Construct a `PrimalGeometricMapSeries` given a primal mesh `s` and a subdivider function like `binary_subdivision`, `levels` times.
-
-The `PrimalGeometricMapSeries` returned contains a list of `levels + 1` dual complexes, with `levels` matrices between the primal vertices of each.
-
-See also: [`AbstractGeometricMapSeries`](@ref), [`finest_mesh`](@ref).
-"""
 function PrimalGeometricMapSeries(s::HasDeltaSet, subdivider::Function, levels::Int, alg = Circumcenter())
-  subdivs = Iterators.reverse(repeated_subdivisions(levels, s, subdivider));
+  subdivs = Iterators.reverse(repeated_subdivision_maps(levels, s, subdivider));
   meshes = [dom.(subdivs)..., s]
   dual_meshes = map(s -> dualize(s, alg), meshes)
   matrices = as_matrix.(subdivs)
   PrimalGeometricMapSeries{typeof(first(dual_meshes)), typeof(first(matrices))}(dual_meshes, matrices)
 end
 
-function normalize_restrictions(ps::Vector{T}) where T <: Diagonal
-  rs = map(ps) do p
-    pt = transpose(p)
-    pt ./ sum(pt, dims=2)
-  end
+# MultigridData
+#--------------
+
+struct MultigridData{Mv}
+  operators::Vector{SparseMatrixCSC{Float64, Int32}}
+  restrictions::Mv
+  prolongations::Mv
+  steps::Vector{Int}
 end
 
-# XXX: Row-normalizing a sparse matrix is non-trivial.
-#https://discourse.julialang.org/t/scaling-a-sparse-matrix-row-wise-and-column-wise-too-slow/115956/8
+MultigridData(g,r,p,s) = MultigridData{typeof(r)}(g,r,p,s)
+MultigridData(g,r,p,s::Int) = MultigridData(g,r,p,fill(s,length(g)))
+
+MGData(series::PrimalGeometricMapSeries, op::Function, s::Int, ::T) where T <: AbstractSubdivisionScheme =
+  MultigridData(series, op, fill(s,length(series.meshes)))
+MGData(series::PrimalGeometricMapSeries, op::Function, s::Int) =
+  MultigridData(series, op, fill(s,length(series.meshes)))
+
+Base.length(md::MultigridData) = length(md.operators)
+
+# AbstractMultigridMode
+#----------------------
+
+"""
+    abstract type AbstractMultigridMode
+
+Controls operator assembly in `MultigridData` construction.
+
+- `DirectMode()`: dualize and discretize at every level during the walk.
+- `GalerkinMode()`: only dualize the finest mesh; derive coarse operators
+  via the Galerkin condition  Aₖ₊₁ = Rₖ Aₖ Pₖ.
+"""
+abstract type AbstractMultigridMode end
+struct DirectMode   <: AbstractMultigridMode end
+struct GalerkinMode <: AbstractMultigridMode end
+
+# Restriction Normalization
+#--------------------------
+
 function row_normalize!(M)
-  row_sums = sum(M, dims=2)
-  rows = rowvals(M)
-  vals = nonzeros(M)
-  n = size(M, 2)
-  for j in 1:n
-    for i in nzrange(M, j)
-      row = rows[i]
-      vals[i] /= row_sums[row]
-    end
+  nrows = size(M, 1)
+  row_sums = zeros(nrows)
+  rvs = rowvals(M)
+  nzv = nonzeros(M)
+  @inbounds for k in eachindex(nzv)
+    row_sums[rvs[k]] += nzv[k]
+  end
+  @inbounds for k in eachindex(nzv)
+    nzv[k] /= row_sums[rvs[k]]
   end
   M
 end
 
-function normalize_restrictions(ps::Vector{T}) where T <: AbstractMatrix
-  rs = map(ps) do p
-    pt = copy(transpose(p))
-    row_normalize!(pt)
+"""
+    make_restriction(p::Transpose{<:Any, <:SparseMatrixCSC})
+
+Build restriction R = row_normalize(S) directly from the subdivision matrix
+S = parent(p), sharing its `colptr` and `rowval` arrays.  Only allocates a
+new `nzval` vector and a temporary row-sum buffer.
+"""
+function make_restriction(p::Transpose{<:Any, <:SparseMatrixCSC})
+  S = parent(p)
+  rv = rowvals(S)
+  nz = nonzeros(S)
+  nrows = size(S, 1)
+
+  row_sums = zeros(nrows)
+  @inbounds for k in eachindex(nz)
+    row_sums[rv[k]] += nz[k]
   end
+
+  new_nz = Vector{Float64}(undef, length(nz))
+  @inbounds for k in eachindex(nz)
+    new_nz[k] = nz[k] / row_sums[rv[k]]
+  end
+
+  SparseMatrixCSC(nrows, size(S, 2), S.colptr, rv, new_nz)
 end
+
+make_restriction(p::Diagonal) = (pt = transpose(p); pt ./ sum(pt, dims=2))
+make_restriction(p::AbstractMatrix) = row_normalize!(copy(transpose(p)))
+
+normalize_restrictions(ps::AbstractVector) = map(make_restriction, ps)
+
+# MultigridData Constructors
+#---------------------------
+
+# --- From PrimalGeometricMapSeries (legacy) ---
 
 function MultigridData(series::PrimalGeometricMapSeries, op::Function, s::AbstractVector)
   ops = op.(meshes(series))
@@ -190,399 +610,253 @@ function MultigridData(series::PrimalGeometricMapSeries, op::Function, s::Abstra
   MultigridData(ops, rs, ps, s)
 end
 
-"""    MultigridData(s::HasDeltaSet, subdivider, levels::Int, op::Function, steps, alg=Circumcenter(); galerkin=false)
+# --- From custom subdivider function (backward compat, no mode dispatch) ---
 
-Construct a `MultigridData` directly from a base mesh without allocating an
-entire `PrimalGeometricMapSeries`. Meshes are subdivided on demand so that at
-most two primal meshes (the current level and its subdivision) are in memory at
-a time.
-
-When `galerkin=false` (default), every level is dualized and `op` is called on
-each dual mesh independently. Only one dual mesh is in memory at a time.
-
-When `galerkin=true`, only the *finest* mesh is dualized and `op` is called
-once. Coarser operators are derived algebraically via the Galerkin condition:
-`A_coarse = R * A_fine * P`. This eliminates all dualizations except one, which
-is typically the dominant cost.
-
-`subdivider` is either a subdivision scheme (e.g. `BinarySubdivision()`) or a
-subdivision map function (e.g. `binary_subdivision_map`).
-
-`steps` may be an `Int` (constant across all grids) or an `AbstractVector`.
-
-# Example
-```julia
-md = MultigridData(s, BinarySubdivision(), 4, s -> ∇²(0, s), 3)
-md = MultigridData(s, BinarySubdivision(), 4, s -> ∇²(0, s), 3; galerkin=true)
-```
-"""
-function MultigridData(s::HasDeltaSet, subdivider::Function, levels::Int, op::Function, steps, alg=Circumcenter(); galerkin=false)
+function MultigridData(s::HasDeltaSet, subdivider::Function, levels::Int,
+                       op::Function, steps, alg=Circumcenter())
   steps_vec = steps isa AbstractVector ? steps : fill(steps, levels + 1)
 
   if levels == 0
-    sd = dualize(s, alg)
-    only_op = op(sd)
+    only_op = op(dualize(s, alg))
     return MultigridData([only_op], typeof(only_op)[], typeof(only_op)[], steps_vec)
   end
 
-  # --- Phase 1: Walk coarse-to-fine, subdividing on demand. ---
-  # Collect subdivision matrices into mats (finest-first).
-  # In non-galerkin mode, also dualize each mesh and stash operators into
-  # coarse_ops (coarsest-first); these are moved into the final vector later.
-
-  coarse_ops = []
-
-  if !galerkin
-    sd = dualize(s, alg)
-    push!(coarse_ops, op(sd))
-  end
-
   current_primal = s
+  sd = dualize(current_primal, alg)
+  first_op = op(sd)
+  sd = nothing
+
   pgm = subdivider(current_primal)
   first_mat = as_matrix(pgm)
-  mats = Vector{typeof(first_mat)}(undef, levels)
-  mats[levels] = first_mat
   current_primal = dom(pgm)
+  pgm = nothing
+
+  first_p = transpose(first_mat)
+  first_r = make_restriction(first_p)
+
+  ops = Vector{typeof(first_op)}(undef, levels + 1)
+  ps  = Vector{typeof(first_p)}(undef, levels)
+  rs  = Vector{typeof(first_r)}(undef, levels)
+  ops[levels + 1] = first_op
+  ps[levels] = first_p
+  rs[levels] = first_r
 
   for i in 2:levels
-    if !galerkin
-      sd = dualize(current_primal, alg)
-      push!(coarse_ops, op(sd))
-    end
+    sd = dualize(current_primal, alg)
+    ops[levels - i + 2] = op(sd)
+    sd = nothing
 
     pgm = subdivider(current_primal)
-    mats[levels - i + 1] = as_matrix(pgm)
-    next_primal = dom(pgm)
-    current_primal = next_primal
+    mat = as_matrix(pgm)
+    current_primal = dom(pgm)
+    pgm = nothing
+
+    idx = levels - i + 1
+    ps[idx] = transpose(mat)
+    rs[idx] = make_restriction(ps[idx])
   end
 
-  # current_primal is now the finest primal mesh.
+  ops[1] = op(dualize(current_primal, alg))
+  MultigridData(ops, rs, ps, steps_vec)
+end
 
-  # --- Phase 2: Dualize the finest mesh (required in both modes). ---
-  sd = dualize(current_primal, alg)
-  finest_op = op(sd)
+# --- Scheme-typed entry point (dispatches on AbstractMultigridMode) ---
 
-  # --- Phase 3: Assemble operators, prolongations, and restrictions. ---
-  ps = transpose.(mats)
-  rs = normalize_restrictions(ps)
+"""
+    MultigridData(s, scheme, levels, op, steps; alg, mode)
 
+Construct a `MultigridData` from a base mesh using topology-only subdivision.
+
+# Keyword arguments
+- `mode::AbstractMultigridMode = DirectMode()`: controls operator assembly.
+- `alg = Circumcenter()`: dualization algorithm.
+
+# Examples
+```julia
+md = MultigridData(s, BinarySubdivision(), 4, s -> ∇²(0, s), 3)
+md = MultigridData(s, BinarySubdivision(), 4, s -> ∇²(0, s), 3; mode=GalerkinMode())
+```
+"""
+function MultigridData(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme,
+                       levels::Int, op::Function, steps; alg=Circumcenter(),
+                       mode::AbstractMultigridMode=DirectMode())
+  _build_multigrid(mode, s, scheme, levels, op, steps, alg)
+end
+
+# Fallback for HasDeltaSet (1D) — delegates to function-based path.
+function MultigridData(s::HasDeltaSet, scheme::AbstractSubdivisionScheme,
+                       levels::Int, op::Function, steps; alg=Circumcenter(),
+                       mode::AbstractMultigridMode=DirectMode())
+  MultigridData(s, x -> subdivision_map(x, scheme), levels, op, steps, alg)
+end
+
+# _build_multigrid
+#-----------------
+
+# The coarse→fine walk is shared:
+#   1. Extract MeshTopology from the base mesh.
+#   2. At each level: propagate points, subdivide topology, build p/r pair.
+#
+# Three phases dispatch on the mode to control operator assembly:
+#   _init_ops          — before the walk
+#   _record_level_op!  — after each subdivision level
+#   _finalize_ops      — after the walk completes
+
+# --- Phase 1: Pre-walk initialization ---
+
+"""Compute the coarsest-level operator before the walk begins."""
+_init_ops(::DirectMode, s, op, alg) = [op(dualize(s, alg))]
+
+"""No operators needed before the walk in Galerkin mode."""
+_init_ops(::GalerkinMode, s, op, alg) = Any[]
+
+# --- Phase 2: Per-level operator recording ---
+
+"""Dualize the current mesh and record its operator."""
+_record_level_op!(::DirectMode, ops, S, topo, points, op, alg) =
+  push!(ops, op(dualize(topo_to_mesh(S, topo, points), alg)))
+
+"""No per-level operators in Galerkin mode."""
+_record_level_op!(::GalerkinMode, ops, S, topo, points, op, alg) = ops
+
+# --- Phase 3: Post-walk finalization ---
+
+"""Direct mode: operators were collected coarsest-first; reverse to finest-first."""
+_finalize_ops(::DirectMode, ops, S, topo, points, ps, rs, levels, op, alg) =
+  reverse(ops)
+
+"""Galerkin mode: dualize the finest mesh, derive coarse operators via Rₖ Aₖ Pₖ."""
+function _finalize_ops(::GalerkinMode, _, S, topo, points, ps, rs, levels, op, alg)
+  finest_op = op(dualize(topo_to_mesh(S, topo, points), alg))
   ops = Vector{typeof(finest_op)}(undef, levels + 1)
   ops[1] = finest_op
-
-  if galerkin
-    # Derive coarser operators via Galerkin condition: A_coarse = R * A_fine * P.
-    for i in 1:levels
-      ops[i + 1] = rs[i] * ops[i] * ps[i]
-    end
-  else
-    # Place the coarse_ops (coarsest-first) into ops (finest-first).
-    for j in 1:levels
-      ops[levels - j + 2] = coarse_ops[j]
-    end
+  for i in 1:levels
+    ops[i + 1] = rs[i] * ops[i] * ps[i]
   end
+  ops
+end
+
+# --- Main walk ---
+
+function _build_multigrid(mode::AbstractMultigridMode, s::HasDeltaSet2D,
+                          scheme::AbstractSubdivisionScheme,
+                          levels::Int, op::Function, steps, alg)
+  steps_vec = steps isa AbstractVector ? steps : fill(steps, levels + 1)
+  S = typeof(s)
+
+  if levels == 0
+    only_op = op(dualize(s, alg))
+    return MultigridData([only_op], typeof(only_op)[], typeof(only_op)[], steps_vec)
+  end
+
+  topo = MeshTopology(s)
+  points = s[:point]
+
+  # Phase 1: Pre-walk operator initialization.
+  ops = _init_ops(mode, s, op, alg)
+
+  # Phase 2: Coarse-to-fine subdivision walk.
+  # First step bootstraps concrete types for ps/rs.
+  points = propagate_points(scheme, topo, points)
+  mat = subdivision_matrix(scheme, topo)
+  topo = refine(scheme, topo)
+  first_p = transpose(mat)
+  first_r = make_restriction(first_p)
+
+  ps = Vector{typeof(first_p)}(undef, levels)
+  rs = Vector{typeof(first_r)}(undef, levels)
+  ps[levels] = first_p
+  rs[levels] = first_r
+  _record_level_op!(mode, ops, S, topo, points, op, alg)
+
+  for i in 2:levels
+    points = propagate_points(scheme, topo, points)
+    mat = subdivision_matrix(scheme, topo)
+    topo = refine(scheme, topo)
+    idx = levels + 1 - i
+    ps[idx] = transpose(mat)
+    rs[idx] = make_restriction(ps[idx])
+    _record_level_op!(mode, ops, S, topo, points, op, alg)
+  end
+
+  # Phase 3: Finalize operator assembly.
+  ops = _finalize_ops(mode, ops, S, topo, points, ps, rs, levels, op, alg)
 
   MultigridData(ops, rs, ps, steps_vec)
 end
 
-# Convenience: accept an AbstractSubdivisionScheme instead of a raw function.
-MultigridData(s::HasDeltaSet, ::UnarySubdivision, levels::Int, op::Function, steps, alg=Circumcenter(); kwargs...) =
-  MultigridData(s, unary_subdivision_map, levels, op, steps, alg; kwargs...)
-MultigridData(s::HasDeltaSet, ::BinarySubdivision, levels::Int, op::Function, steps, alg=Circumcenter(); kwargs...) =
-  MultigridData(s, binary_subdivision_map, levels, op, steps, alg; kwargs...)
-MultigridData(s::HasDeltaSet, ::CubicSubdivision, levels::Int, op::Function, steps, alg=Circumcenter(); kwargs...) =
-  MultigridData(s, cubic_subdivision_map, levels, op, steps, alg; kwargs...)
+# Utility
+#--------
 
-# XXX: This function does not detect e.g. dangling edges.
 function is_simplicial_complex(s::HasDeltaSet2D)
   allunique(map(x -> edge_vertices(s,x), edges(s))) &&
   allunique(map(x -> triangle_vertices(s,x), triangles(s)))
 end
 
-# Subdivision Algorithms
-#-----------------------
-
-# Subdivide each triangle into 1 via "unary" a.k.a. "trivial" subdivision,
-# returning a primal simplicial complex.
-function unary_subdivision(s::Union{EmbeddedDeltaSet1D, EmbeddedDeltaSet2D})
-  sd = copy(s)
-  sd
-end
-
-function unary_subdivision_map(s)
-  sd = unary_subdivision(s)
-  PrimalGeometricMap(sd, s, I(nv(s)))
-end
-
-"""
-Subdivide each triangle into 4 via "binary" a.k.a. "medial" subdivision,
-returning a primal simplicial complex.
-"""
-function binary_subdivision(s::Union{EmbeddedDeltaSet1D, EmbeddedDeltaSet2D})
-  # TODO: Refactor the dispatch here.
-  ntriangles(s::EmbeddedDeltaSet1D) = 0
-  ntriangles(s::EmbeddedDeltaSet2D) = nparts(s,:Tri)
-  triangles(s::EmbeddedDeltaSet1D) = 1:0
-  triangles(s::EmbeddedDeltaSet2D) = parts(s,:Tri)
-  sd = typeof(s)()
-  add_vertices!(sd,nv(s)+ne(s))
-  sd[1:nv(s), :point] = s[:point]
-  sd[(nv(s)+1:nv(s)+ne(s)), :point] = (s[[:∂v0,:point]] .+ s[[:∂v1,:point]])./2
-
-  # v0 -- m -- v1
-  add_parts!(sd, :E, 2*ne(s)+3*ntriangles(s))
-  for e in edges(s)
-    offset = 2*e-1
-    e_idxs = SVector{2}(offset, offset+1)
-    m = e+nv(s)
-
-    sd[e_idxs, :∂v0] = m,          m
-    sd[e_idxs, :∂v1] = s[e, :∂v0], s[e, :∂v1]
-  end
-
-  #       v2
-  #      /  \
-  #    m1 -- m0
-  #   /  \  /  \
-  # v0 -- m2 -- v1
-  if s isa EmbeddedDeltaSet2D
-    add_parts!(sd, :Tri, 4*ntriangles(s))
-  end
-  inc_arr = SVector{3}(0,1,2)
-  for t in triangles(s)
-    es = triangle_edges(s,t)
-
-    # Vertex indices:
-    m0, m1, m2 = es .+ nv(s)
-
-    # Edge indices:
-    m0_m1, m1_m2, m0_m2 = (3t-2 + 2ne(s)) .+ inc_arr
-    m0_v1, m1_v0, m2_v0 = 2es
-    v2_m0, v2_m1, v1_m2 = 2es .- 1
-
-    # Vertex × Edge:
-    sd[SVector{3}(m0_m1, m1_m2, m0_m2), :∂v0] = m1, m2, m2
-    sd[SVector{3}(m0_m1, m1_m2, m0_m2), :∂v1] = m0, m1, m0
-
-    # Edge × Triangle:
-    offset = 4t-3
-    tri_idxs = SVector{4}(offset, offset+1, offset+2, offset+3)
-    sd[tri_idxs, :∂e0] = m1_m2, m1_m2, m0_m2, m0_m1
-    sd[tri_idxs, :∂e1] = m0_m2, m2_v0, v1_m2, v2_m1
-    sd[tri_idxs, :∂e2] = m0_m1, m1_v0, m0_v1, v2_m0
-  end
-  sd
-end
-
-function binary_subdivision_map(s)
-  sd = binary_subdivision(s)
-
-  nentries = nv(s) + 2*ne(s)
-
-  I = zeros(Int32, nentries)
-  J = zeros(Int32, nentries)
-  V = ones(nentries)
-
-  # Map old point back to same point
-  for i in vertices(s) I[i]=J[i]=i; end
-
-  # Map edge points to midpoint by average
-  for i in edges(s)
-    arr_i = nv(s) + 2i - 1
-    shift_i = nv(s) + i
-
-    I[arr_i], I[arr_i+1] = s[i, :∂v0], s[i, :∂v1]
-    J[arr_i], J[arr_i+1] = shift_i, shift_i
-    V[arr_i], V[arr_i+1] = 1/2, 1/2
-  end
-
-  PrimalGeometricMap(sd,s,sparse(I,J,V))
-end
-
-"""
-Subdivide each triangle into 9 via cubic subdivision, returning a primal simplicial complex.
-"""
-function cubic_subdivision(s::Union{EmbeddedDeltaSet1D, EmbeddedDeltaSet2D})
-  ntriangles(s::EmbeddedDeltaSet1D) = 0
-  ntriangles(s::EmbeddedDeltaSet2D) = nparts(s,:Tri)
-  triangles(s::EmbeddedDeltaSet1D) = 1:0
-  triangles(s::EmbeddedDeltaSet2D) = parts(s,:Tri)
-  sd = typeof(s)()
-  add_vertices!(sd, nv(s)+2ne(s)+ntriangles(s))
-  sd[1:nv(s), :point] =
-    s[:point]
-  sd[(nv(s)+1:nv(s)+2ne(s)), :point] = reduce(vcat, map(edges(s)) do e
-    v0, v1 = s[s[e, :∂v0], :point], s[s[e, :∂v1], :point]
-    [(2v0 + v1)/3, (v0 + 2v1)/3]
-  end)
-  sd[(nv(s)+2ne(s)+1:nv(s)+2ne(s)+ntriangles(s)), :point] =
-    (s[[:∂e1,:∂v1,:point]] .+ s[[:∂e0,:∂v1,:point]] .+ s[[:∂e0,:∂v0,:point]])./3
-
-  # v0 -> m0 -> m1 -> v1
-  add_parts!(sd, :E, 3ne(s)+9ntriangles(s))
-  for e in edges(s)
-    offset = 3*e-2
-    e_idxs = SVector{3}(offset, offset+1, offset+2)
-    m0, m1 = nv(s)+2*e-1, nv(s)+2*e
-    v0, v1 = s[e, :∂v0], s[e, :∂v1]
-
-    sd[e_idxs, :∂v0] = m0, m1, v1
-    sd[e_idxs, :∂v1] = v0, m0, m1
-  end
-
-  #          030
-  #         ^  v
-  #       021 > 120
-  #      ^  ^  ^  v
-  #    012< 111  >210
-  #   ^  ^  ^  ^  ^  v
-  # 003 >102  >201  >300
-  if s isa EmbeddedDeltaSet2D
-    add_parts!(sd, :Tri, 9ntriangles(s))
-  end
-  inc_arr = SVector{9}(0,1,2,3,4,5,6,7,8)
-  for t in triangles(s)
-    es = triangle_edges(s,t)
-
-    # Vertex indices:
-    m012, m102, m120 = 2*es .+ nv(s) .- 1
-    m021, m201, m210 = 2*es .+ nv(s)
-    m111 = nv(s)+2ne(s)+t
-
-    # Edge indices:
-    ms = (3ne(s) + 9t-8) .+ inc_arr
-    m201_m210, m201_m111, m102_m111,
-    m102_m012, m111_m012, m111_m021,
-    m111_m210, m111_m120, m021_m120 = ms
-    m021_v030, m201_v300, m210_v300 = 3es
-    m012_m021, m102_m201, m120_m210 = 3es .- 1
-    v003_m012, v003_m102, v030_m120 = 3es .- 2
-
-    # Vertex × Edge:
-    sd[ms, :∂v0] = m210, m111, m111, m012, m012, m021, m210, m120, m120
-    sd[ms, :∂v1] = m201, m201, m102, m102, m111, m111, m111, m111, m021
-
-    # Edge × Triangle:
-    offset = 9t-8
-    tri_idxs = offset .+ inc_arr
-    sd[tri_idxs, :∂e0] = m210_v300, m111_m210, m201_m111, m111_m012, m102_m012, m120_m210, m021_m120, m012_m021, v030_m120
-    sd[tri_idxs, :∂e1] = m201_v300, m201_m210, m102_m111, m102_m012, v003_m012, m111_m210, m111_m120, m111_m021, m021_m120
-    sd[tri_idxs, :∂e2] = m201_m210, m201_m111, m102_m201, m102_m111, v003_m102, m111_m120, m111_m021, m111_m012, m021_v030
-  end
-  sd
-end
-
-function cubic_subdivision_map(s)
-  ntriangles(s::EmbeddedDeltaSet1D) = 0
-  ntriangles(s::EmbeddedDeltaSet2D) = nparts(s,:Tri)
-  triangles(s::EmbeddedDeltaSet1D) = 1:0
-  triangles(s::EmbeddedDeltaSet2D) = parts(s,:Tri)
-  sd = cubic_subdivision(s)
-
-  nentries = 1*nv(s) + 2*(2*ne(s)) + 3*ntriangles(s)
-
-  I = zeros(Int32, nentries)
-  J = zeros(Int32, nentries)
-  V = ones(nentries)
-
-  # Original points:
-  for i in vertices(s) I[i]=J[i]=i; end
-
-  # Points along original edges:
-  for i in edges(s)
-    arr_i = nv(s) + 4i - 3
-    arr_idxs = SVector(arr_i, arr_i+1, arr_i+2, arr_i+3)
-    shift_i = nv(s) + 2*i - 1
-
-    I[arr_idxs] = [s[i, :∂v0], s[i, :∂v1], s[i, :∂v1], s[i, :∂v0]]
-    J[arr_idxs] = [shift_i, shift_i, shift_i+1, shift_i+1]
-    V[arr_idxs] = [2/3, 1/3, 2/3, 1/3]
-  end
-
-  # Points at triangle centers:
-  for i in triangles(s)
-    arr_i = (nv(s) + (2*2*ne(s))) + 3*i - 2
-    arr_idxs = SVector(arr_i, arr_i+1, arr_i+2)
-    shift_i = nv(s) + 2*ne(s) + i
-
-    I[arr_idxs] = [s[s[i, :∂e1], :∂v1], s[s[i, :∂e0], :∂v1], s[s[i, :∂e0], :∂v0]]
-    J[arr_idxs] .= shift_i
-    V[arr_idxs] = [1/3, 1/3, 1/3]
-  end
-
-  PrimalGeometricMap(sd,s,sparse(I,J,V))
-end
-
-repeated_subdivisions(k, ss, subdivider) =
-  accumulate((x,_) -> subdivider(x), 1:k; init=ss)
-
 # Multigrid Algorithms
 #---------------------
 
-# TODO:
-# - Smarter calculations for steps and cycles,
-# - Input arbitrary iterative solver,
-# - Implement weighted Jacobi and maybe Gauss-Seidel,
-# - Masking for boundary condtions
-# - This could use Galerkin conditions to construct As from As[1] (see galerkin=true in MultigridData constructor)
-# - Add maxcycles and tolerances
 """
-Solve `Ax=b` on `s` with initial guess `u` using , for `cycles` V-cycles, performing `md.steps` steps of the
-conjugate gradient method on each mesh and going through
-`cycles` total V-cycles. Everything is just matrices and vectors
-at this point.
-
-Warning:
-Quoting from the Krylov.jl documentation:
-> itmax: the maximum number of iterations. If itmax=0, the default number of iterations is set to 2n;
-
-, where n is the length of the solution vector.
-We diverge from this behavior and perform no iterations when the corresponding element of `md.steps` is `0`.
-
-`alg` is a Krylov.jl method, probably either the default `cg` or
-`gmres`.
+Solve `Ax=b` with initial guess `u` for `cycles` V-cycles.
+`alg` is a Krylov.jl method (default `cg`).
 """
 multigrid_vcycles(u, b, md, cycles, alg=cg) = multigrid_μ_cycles(u, b, md, cycles, alg, 1)
 
-"""
-Just the same as `multigrid_vcycles` but with W-cycles.
-"""
+"""W-cycle variant of `multigrid_vcycles`."""
 multigrid_wcycles(u, b, md, cycles, alg=cg) = multigrid_μ_cycles(u, b, md, cycles, alg, 2)
 
 function multigrid_μ_cycles(u, b, md::MultigridData, cycles, alg=cg, μ=1)
-  cycles == 0 && return u
-  u = _multigrid_μ_cycle(u,b,md,alg,μ)
-  multigrid_μ_cycles(u,b,md,cycles-1,alg,μ)
+  for _ in 1:cycles
+    u = _multigrid_μ_cycle(u, b, md, 1, alg, μ)
+  end
+  u
 end
 
 """
-The full multigrid framework: start at the coarsest grid and
-work your way up, applying V-cycles or W-cycles at each level
-according as μ is 1 or 2.
+Full multigrid: start at the coarsest grid and work up, applying
+μ-cycles at each level (μ=1 for V, μ=2 for W).
 """
 function full_multigrid(b, md::MultigridData, cycles, alg=cg, μ=1)
   z_f = zeros(size(b))
   if length(md) > 1
-    r,p = car(md)[2:3]
+    r = md.restrictions[1]
+    p = md.prolongations[1]
     b_c = r * b
-    z_c = full_multigrid(b_c, cdr(md), cycles, alg, μ)
+    z_c = _full_multigrid(b_c, md, 2, cycles, alg, μ)
     z_f = p * z_c
   end
-  multigrid_μ_cycles(z_f,b,md,cycles,alg,μ)
+  multigrid_μ_cycles(z_f, b, md, cycles, alg, μ)
 end
 
-function _multigrid_μ_cycle(u, b, md::MultigridData, alg=cg, μ=1)
-  A,r,p,steps = car(md)
-  # Manually perform 0 steps, unlike the 2n step default of Krylov.jl.
-  u = steps == 0 ? u : alg(A,b,u,itmax=steps)[1]
-  length(md) == 1 && return u
-  r_f = b - A*u
+function _full_multigrid(b, md::MultigridData, lvl, cycles, alg, μ)
+  z_f = zeros(size(b))
+  if lvl < length(md)
+    r = md.restrictions[lvl]
+    p = md.prolongations[lvl]
+    b_c = r * b
+    z_c = _full_multigrid(b_c, md, lvl + 1, cycles, alg, μ)
+    z_f = p * z_c
+  end
+  for _ in 1:cycles
+    z_f = _multigrid_μ_cycle(z_f, b, md, lvl, alg, μ)
+  end
+  z_f
+end
+
+function _multigrid_μ_cycle(u, b, md::MultigridData, lvl, alg=cg, μ=1)
+  A     = md.operators[lvl]
+  steps = md.steps[lvl]
+  u = steps == 0 ? u : alg(A, b, u, itmax=steps)[1]
+  lvl >= length(md) && return u
+  r = md.restrictions[lvl]
+  p = md.prolongations[lvl]
+  r_f = b - A * u
   r_c = r * r_f
-  z = _multigrid_μ_cycle(zeros(size(r_c)), r_c, cdr(md), alg, μ)
+  z = _multigrid_μ_cycle(zeros(size(r_c)), r_c, md, lvl + 1, alg, μ)
   if μ > 1
-    z = _multigrid_μ_cycle(z, r_c, cdr(md), alg, μ-1)
+    z = _multigrid_μ_cycle(z, r_c, md, lvl + 1, alg, μ - 1)
   end
   u += p * z
-  # Manually perform 0 steps, unlike the 2n step default of Krylov.jl.
   u = steps == 0 ? u : alg(A, b, u, itmax=steps)[1]
 end
 

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -26,7 +26,7 @@ export Simplex, V, E, Tri, Tet, SimplexChain, VChain, EChain, TriChain, TetChain
   EmbeddedDeltaSet3D, SchEmbeddedDeltaSet3D,
   ∂, boundary, coface, d, coboundary, exterior_derivative,
   simplices, nsimplices, point, volume,
-  orientation, set_orientation!, orient!, orient_component!,
+  orientation, set_orientation!, orient!,
   src, tgt, nv, ne, vertices, edges, has_vertex, has_edge, edge_vertices,
   add_vertex!, add_vertices!, add_edge!, add_edges!,
   add_sorted_edge!, add_sorted_edges!,
@@ -785,95 +785,98 @@ operator_nz(f, ::Type{T}, m::Int, n::Int,
 # Consistent orientation
 ########################
 
-""" Consistently orient simplices in a simplicial set, if possible.
-
-Two simplices with a common face are *consistently oriented* if they induce
-opposite orientations on the shared face. This function attempts to consistently
-orient all simplices of a given dimension and returns whether this has been
-achieved. Each connected component is oriently independently using the helper
-function [`orient_component!`](@ref).
-"""
 orient!(s::AbstractDeltaSet1D) = orient!(s, Val(1))
 orient!(s::AbstractDeltaSet2D) = orient!(s, Val(2))
 orient!(s::AbstractDeltaSet3D) = orient!(s, Val(3))
 
+"""    function orient!(s::HasDeltaSet, ::Val{n}) where n
+
+Consistently orient simplices in the same connected component, if possible.
+
+Two simplices with a common face are *consistently oriented* if they induce
+opposite orientations on the shared face. Given a delta set, this function
+attempts to consistently orient all ``n``-simplices that may be reached from it
+by traversing ``(n-1)``-faces. The traversal is depth-first. If a consistent
+orientation is possible, the function returns `true` and the orientations are
+assigned; otherwise, it returns `false` and no orientations are changed.
+"""
 function orient!(s::HasDeltaSet, ::Val{n}) where n
-  # Compute connected components as coequalizer of face maps.
+  # Empty delta sets are oriented by definition.
+  nsimplices(n, s) == 0 && return true
+  neighbors(x) = (coface(n, j, s, ∂(n, i, s, x)) for i in 0:n for j in 0:n)
+
+  # Perform DFS.
+  ors = zeros(Int8, nsimplices(n, s)) # (-1, 0, 1)::(negative, visited, positive)
+  stack = Int[]
+  for seed in simplices(n, s)
+    @inbounds ors[seed] != 0 && continue
+    empty!(stack) # Invariant.
+    push!(stack, seed)
+    @inbounds ors[seed] = 1
+    while !isempty(stack)
+      x = pop!(stack)
+      @inbounds ox = ors[x]
+      nox = -ox
+      for i in 0:n
+        face = ∂(n, i, s, x)
+        for j in 0:n
+          y = coface(n, j, s, face)
+          y == x && continue
+          oy = ors[y]
+          if oy == 0
+            @inbounds ors[y] = nox
+            push!(stack, y)
+          elseif oy == ox
+            return false
+          end
+        end
+      end
+    end
+  end
+
+  # Map from sentinel types to attr types.
+  seed_o = one(attrtype_type(s, :Orientation))
+  attr_ors = [val == 1 ? seed_o : negate(seed_o) for val in ors]
+  set_orientation!(n, s, simplices(n, s), attr_ors)
+  return true
+end
+
+negate(x) = -x
+negate(x::Bool) = !x
+
+# Connected components
+######################
+
+"""    function connected_components(s::HasDeltaSet, ::Val{n}) where n
+
+Compute connected components as coequalizer of face maps.
+
+See also [`connected_components_representatives`](@ref).
+"""
+function connected_components(s::HasDeltaSet, ::Val{n}) where n
   ndom, ncodom = nsimplices(n, s), nsimplices(n-1, s)
   face_maps = [ FinFunction(x -> ∂(n,i,s,x), FinSet(ndom), FinSet(ncodom))
                 for i in 0:n ]
   π = only(coequalizer[𝒞](face_maps))
+end
+
+"""    function connected_components_representatives(s::HasDeltaSet, ::Val{n}) where n
+
+Compute connected components as coequalizer of face maps, and return a simplex from each.
+
+See also [`connected_components`](@ref).
+"""
+function connected_components_representatives(s::HasDeltaSet, ::Val{n}) where n
+  π = connected_components(s, n)
 
   # Choose an arbitrary representative of each component.
   reps = zeros(Int, length(codom(π)))
   for x in reverse(simplices(n, s))
     reps[π(∂(n,0,s,x))] = x
   end
-
-  # Orient each component, starting at the chosen representative.
-  init_orientation = one(attrtype_type(s, :Orientation))
-  for x in reps
-    #orient_component!(s, Simplex{n}(x), init_orientation) || return false
-    orient_component!(Val(n), s, x, init_orientation) || return false
-  end
-  true
+  reps
 end
 
-""" Consistently orient simplices in the same connected component, if possible.
-
-Given an ``n``-simplex and a choice of orientation for it, this function
-attempts to consistently orient all ``n``-simplices that may be reached from it
-by traversing ``(n-1)``-faces. The traversal is depth-first. If a consistent
-orientation is possible, the function returns `true` and the orientations are
-assigned; otherwise, it returns `false` and no orientations are changed.
-
-If the simplicial set is not connected, the function [`orient!`](@ref) may be
-more convenient.
-"""
-orient_component!(s::AbstractDeltaSet1D, e::Int, args...) =
-  orient_component!(Val(1), s, e, args...)
-orient_component!(s::AbstractDeltaSet2D, t::Int, args...) =
-  orient_component!(Val(2), s, t, args...)
-orient_component!(s::AbstractDeltaSet3D, tet::Int, args...) =
-  orient_component!(Val(3), s, tet, args...)
-
-function orient_component!(::Val{n}, s::HasDeltaSet, x,
-                           x_orientation::Orientation) where {n, Orientation}
-  orientations = repeat(Union{Orientation,Nothing}[nothing], nsimplices(n, s))
-
-  orient_stack = Vector{Pair{Int64, Orientation}}()
-
-  # TODO: Make this an Int32 or Int.
-  #push!(orient_stack, Int64[] => x_orientation)
-  push!(orient_stack, x => x_orientation)
-  is_orientable = true
-  while !isempty(orient_stack)
-    x, target = pop!(orient_stack)
-    current = orientations[x]
-    if isnothing(current)
-      # If not visited, set the orientation and add neighbors to stack.
-      orientations[x] = target
-      for i in 0:n, j in 0:n
-        next = iseven(i+j) ? negate(target) : target
-        for y in coface(n, j, s, ∂(n, i, s, x))
-          y == x || push!(orient_stack, y=>next)
-        end
-      end
-    elseif current != target
-      is_orientable = false
-      break
-    end
-  end
-
-  if is_orientable
-    component = findall(!isnothing, orientations)
-    set_orientation!(n, s, component, orientations[component])
-  end
-  is_orientable
-end
-
-negate(x) = -x
-negate(x::Bool) = !x
 
 # Euclidean geometry
 ####################

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -62,7 +62,7 @@ const HasDeltaSet0D = HasDeltaSet
 
 vertices(s::HasDeltaSet) = parts(s, :V)
 nv(s::HasDeltaSet) = nparts(s, :V)
-nsimplices(::Type{Val{0}}, s::HasDeltaSet) = nv(s)
+nsimplices(::Val{0}, s::HasDeltaSet) = nv(s)
 
 has_vertex(s::HasDeltaSet, v) = has_part(s, :V, v)
 add_vertex!(s::HasDeltaSet; kw...) = add_part!(s, :V; kw...)
@@ -122,7 +122,7 @@ edges(s::HasDeltaSet1D, src::Int, tgt::Int) =
 
 ne(::HasDeltaSet) = 0
 ne(s::HasDeltaSet1D) = nparts(s, :E)
-nsimplices(::Type{Val{1}}, s::HasDeltaSet1D) = ne(s)
+nsimplices(::Val{1}, s::HasDeltaSet1D) = ne(s)
 
 has_edge(s::HasDeltaSet1D, e) = has_part(s, :E, e)
 has_edge(s::HasDeltaSet1D, src::Int, tgt::Int) =
@@ -130,11 +130,11 @@ has_edge(s::HasDeltaSet1D, src::Int, tgt::Int) =
 
 src(s::HasDeltaSet1D, args...) = subpart(s, args..., :∂v1)
 tgt(s::HasDeltaSet1D, args...) = subpart(s, args..., :∂v0)
-face(::Type{Val{(1,0)}}, s::HasDeltaSet1D, args...) = subpart(s, args..., :∂v0)
-face(::Type{Val{(1,1)}}, s::HasDeltaSet1D, args...) = subpart(s, args..., :∂v1)
+face(::Val{1}, ::Val{0}, s::HasDeltaSet1D, args...) = subpart(s, args..., :∂v0)
+face(::Val{1}, ::Val{1}, s::HasDeltaSet1D, args...) = subpart(s, args..., :∂v1)
 
-coface(::Type{Val{(1,0)}}, s::HasDeltaSet1D, args...) = incident(s, args..., :∂v0)
-coface(::Type{Val{(1,1)}}, s::HasDeltaSet1D, args...) = incident(s, args..., :∂v1)
+coface(::Val{1}, ::Val{0}, s::HasDeltaSet1D, args...) = incident(s, args..., :∂v0)
+coface(::Val{1}, ::Val{1}, s::HasDeltaSet1D, args...) = incident(s, args..., :∂v1)
 
 """ Boundary vertices of an edge.
 """
@@ -177,16 +177,16 @@ true/positive and from target to source when it is false/negative.
 @acset_type OrientedDeltaSet1D(SchOrientedDeltaSet1D,
                                index=[:∂v0,:∂v1]) <: AbstractDeltaSet1D
 
-orientation(::Type{Val{1}}, s::HasDeltaSet1D, args...) =
+orientation(::Val{1}, s::HasDeltaSet1D, args...) =
   s[args..., :edge_orientation]
-set_orientation!(::Type{Val{1}}, s::HasDeltaSet1D, e, orientation) =
+set_orientation!(::Val{1}, s::HasDeltaSet1D, e, orientation) =
   (s[e, :edge_orientation] = orientation)
 
-function ∂_nz(::Type{Val{1}}, s::HasDeltaSet1D, e::Int)
+function ∂_nz(::Val{1}, s::HasDeltaSet1D, e::Int)
   (edge_vertices(s, e), sign(1,s,e) * @SVector([1,-1]))
 end
 
-function d_nz(::Type{Val{0}}, s::HasDeltaSet1D, v::Int)
+function d_nz(::Val{0}, s::HasDeltaSet1D, v::Int)
   e₀, e₁ = coface(1,0,s,v), coface(1,1,s,v)
   (lazy(vcat, e₀, e₁), lazy(vcat, sign(1,s,e₀), -sign(1,s,e₁)))
 end
@@ -210,9 +210,9 @@ point(s::HasDeltaSet, args...) = s[args..., :point]
 
 struct CayleyMengerDet end
 
-volume(::Type{Val{n}}, s::EmbeddedDeltaSet1D, x) where n =
-  volume(Val{n}, s, x, CayleyMengerDet())
-volume(::Type{Val{1}}, s::HasDeltaSet1D, e::Int, ::CayleyMengerDet) =
+volume(::Val{n}, s::EmbeddedDeltaSet1D, x) where n =
+  volume(Val(n), s, x, CayleyMengerDet())
+volume(::Val{1}, s::HasDeltaSet1D, e::Int, ::CayleyMengerDet) =
   volume(point(s, edge_vertices(s, e)))
 
 # 2D simplicial sets
@@ -282,15 +282,15 @@ end
 
 ntriangles(s::HasDeltaSet2D) = nparts(s, :Tri)
 ntriangles(s::HasDeltaSet) = 0
-nsimplices(::Type{Val{2}}, s::HasDeltaSet2D) = ntriangles(s)
+nsimplices(::Val{2}, s::HasDeltaSet2D) = ntriangles(s)
 
-face(::Type{Val{(2,0)}}, s::HasDeltaSet2D, args...) = subpart(s, args..., :∂e0)
-face(::Type{Val{(2,1)}}, s::HasDeltaSet2D, args...) = subpart(s, args..., :∂e1)
-face(::Type{Val{(2,2)}}, s::HasDeltaSet2D, args...) = subpart(s, args..., :∂e2)
+face(::Val{2}, ::Val{0}, s::HasDeltaSet2D, args...) = subpart(s, args..., :∂e0)
+face(::Val{2}, ::Val{1}, s::HasDeltaSet2D, args...) = subpart(s, args..., :∂e1)
+face(::Val{2}, ::Val{2}, s::HasDeltaSet2D, args...) = subpart(s, args..., :∂e2)
 
-coface(::Type{Val{(2,0)}}, s::HasDeltaSet2D, args...) = incident(s, args..., :∂e0)
-coface(::Type{Val{(2,1)}}, s::HasDeltaSet2D, args...) = incident(s, args..., :∂e1)
-coface(::Type{Val{(2,2)}}, s::HasDeltaSet2D, args...) = incident(s, args..., :∂e2)
+coface(::Val{2}, ::Val{0}, s::HasDeltaSet2D, args...) = incident(s, args..., :∂e0)
+coface(::Val{2}, ::Val{1}, s::HasDeltaSet2D, args...) = incident(s, args..., :∂e1)
+coface(::Val{2}, ::Val{2}, s::HasDeltaSet2D, args...) = incident(s, args..., :∂e2)
 
 """ Boundary edges of a triangle.
 """
@@ -380,17 +380,17 @@ true/positive and in the reverse order when it is false/negative.
 @acset_type OrientedDeltaSet2D(SchOrientedDeltaSet2D,
                                index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2]) <: AbstractDeltaSet2D
 
-orientation(::Type{Val{2}}, s::HasDeltaSet2D, args...) =
+orientation(::Val{2}, s::HasDeltaSet2D, args...) =
   s[args..., :tri_orientation]
-set_orientation!(::Type{Val{2}}, s::HasDeltaSet2D, t, orientation) =
+set_orientation!(::Val{2}, s::HasDeltaSet2D, t, orientation) =
   (s[t, :tri_orientation] = orientation)
 
-function ∂_nz(::Type{Val{2}}, s::HasDeltaSet2D, t::Int)
+function ∂_nz(::Val{2}, s::HasDeltaSet2D, t::Int)
   edges = triangle_edges(s,t)
   (edges, sign(2,s,t) * sign(1,s,edges) .* @SVector([1,-1,1]))
 end
 
-function d_nz(::Type{Val{1}}, s::HasDeltaSet2D, e::Int)
+function d_nz(::Val{1}, s::HasDeltaSet2D, e::Int)
   sgn = sign(1, s, e)
   t₀, t₁, t₂ = coface(2,0,s,e), coface(2,1,s,e), coface(2,2,s,e)
   (lazy(vcat, t₀, t₁, t₂),
@@ -410,9 +410,9 @@ end
 @acset_type EmbeddedDeltaSet2D(SchEmbeddedDeltaSet2D,
                                index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2]) <: AbstractDeltaSet2D
 
-volume(::Type{Val{n}}, s::EmbeddedDeltaSet2D, x) where n =
-  volume(Val{n}, s, x, CayleyMengerDet())
-volume(::Type{Val{2}}, s::HasDeltaSet2D, t::Int, ::CayleyMengerDet) =
+volume(::Val{n}, s::EmbeddedDeltaSet2D, x) where n =
+  volume(Val(n), s, x, CayleyMengerDet())
+volume(::Val{2}, s::HasDeltaSet2D, t::Int, ::CayleyMengerDet) =
   volume(point(s, triangle_vertices(s,t)))
 
 # 3D simplicial sets
@@ -449,17 +449,17 @@ end
 
 tetrahedra(s::HasDeltaSet3D) = parts(s, :Tet)
 ntetrahedra(s::HasDeltaSet3D) = nparts(s, :Tet)
-nsimplices(::Type{Val{3}}, s::HasDeltaSet3D) = ntetrahedra(s)
+nsimplices(::Val{3}, s::HasDeltaSet3D) = ntetrahedra(s)
 
-face(::Type{Val{(3,0)}}, s::HasDeltaSet3D, args...) = subpart(s, args..., :∂t0)
-face(::Type{Val{(3,1)}}, s::HasDeltaSet3D, args...) = subpart(s, args..., :∂t1)
-face(::Type{Val{(3,2)}}, s::HasDeltaSet3D, args...) = subpart(s, args..., :∂t2)
-face(::Type{Val{(3,3)}}, s::HasDeltaSet3D, args...) = subpart(s, args..., :∂t3)
+face(::Val{3}, ::Val{0}, s::HasDeltaSet3D, args...) = subpart(s, args..., :∂t0)
+face(::Val{3}, ::Val{1}, s::HasDeltaSet3D, args...) = subpart(s, args..., :∂t1)
+face(::Val{3}, ::Val{2}, s::HasDeltaSet3D, args...) = subpart(s, args..., :∂t2)
+face(::Val{3}, ::Val{3}, s::HasDeltaSet3D, args...) = subpart(s, args..., :∂t3)
 
-coface(::Type{Val{(3,0)}}, s::HasDeltaSet3D, args...) = incident(s, args..., :∂t0)
-coface(::Type{Val{(3,1)}}, s::HasDeltaSet3D, args...) = incident(s, args..., :∂t1)
-coface(::Type{Val{(3,2)}}, s::HasDeltaSet3D, args...) = incident(s, args..., :∂t2)
-coface(::Type{Val{(3,3)}}, s::HasDeltaSet3D, args...) = incident(s, args..., :∂t3)
+coface(::Val{3}, ::Val{0}, s::HasDeltaSet3D, args...) = incident(s, args..., :∂t0)
+coface(::Val{3}, ::Val{1}, s::HasDeltaSet3D, args...) = incident(s, args..., :∂t1)
+coface(::Val{3}, ::Val{2}, s::HasDeltaSet3D, args...) = incident(s, args..., :∂t2)
+coface(::Val{3}, ::Val{3}, s::HasDeltaSet3D, args...) = incident(s, args..., :∂t3)
 
 """ Boundary triangles of a tetrahedron.
 """
@@ -571,17 +571,17 @@ end
 @acset_type OrientedDeltaSet3D(SchOrientedDeltaSet3D,
                                index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:∂t0,:∂t1,:∂t2,:∂t3]) <: AbstractDeltaSet3D
 
-orientation(::Type{Val{3}}, s::HasDeltaSet3D, args...) =
+orientation(::Val{3}, s::HasDeltaSet3D, args...) =
   s[args..., :tet_orientation]
-set_orientation!(::Type{Val{3}}, s::HasDeltaSet3D, t, orientation) =
+set_orientation!(::Val{3}, s::HasDeltaSet3D, t, orientation) =
   (s[t, :tet_orientation] = orientation)
 
-function ∂_nz(::Type{Val{3}}, s::HasDeltaSet3D, tet::Int)
+function ∂_nz(::Val{3}, s::HasDeltaSet3D, tet::Int)
   tris = tetrahedron_triangles(s, tet)
   (tris, sign(3,s,tet) * sign(2,s,tris) .* @SVector([1,-1,1,-1]))
 end
 
-function d_nz(::Type{Val{2}}, s::HasDeltaSet3D, tri::Int)
+function d_nz(::Val{2}, s::HasDeltaSet3D, tri::Int)
   t₀, t₁, t₂, t₃ = map(x -> coface(3,x,s,tri), 0:3)
   sgn = sign(2, s, tri)
   (lazy(vcat, t₀, t₁, t₂, t₃),
@@ -602,9 +602,9 @@ end
 @acset_type EmbeddedDeltaSet3D(SchEmbeddedDeltaSet3D,
                                index=[:∂v0,:∂v1,:∂e0,:∂e1,:∂e2,:∂t0,:∂t1,:∂t2,:∂t3]) <: AbstractDeltaSet3D
 
-volume(::Type{Val{n}}, s::EmbeddedDeltaSet3D, x) where n =
-  volume(Val{n}, s, x, CayleyMengerDet())
-volume(::Type{Val{3}}, s::HasDeltaSet3D, t::Int, ::CayleyMengerDet) =
+volume(::Val{n}, s::EmbeddedDeltaSet3D, x) where n =
+  volume(Val(n), s, x, CayleyMengerDet())
+volume(::Val{3}, s::HasDeltaSet3D, t::Int, ::CayleyMengerDet) =
   volume(point(s, tetrahedron_vertices(s,t)))
 
 const EmbeddedDeltaSet = Union{EmbeddedDeltaSet1D, EmbeddedDeltaSet2D, EmbeddedDeltaSet3D}
@@ -647,10 +647,10 @@ const Tet = Simplex{3}
 
 # could generalize to Simplex{n, N}
 function simplex_vertices(s::HasDeltaSet, x::Simplex{n,0}) where n
-  simplex_vertices(Val{n}, s, x)
+  simplex_vertices(Val(n), s, x)
 end
 
-function simplex_vertices(::Type{Val{n}},s::HasDeltaSet,x::Simplex{n,0}) where n
+function simplex_vertices(::Val{n},s::HasDeltaSet,x::Simplex{n,0}) where n
   n == 0 && return [x.data]
   n == 1 && return edge_vertices(s, x.data)
   n == 2 && return triangle_vertices(s, x.data)
@@ -680,11 +680,11 @@ const TetForm = SimplexForm{3}
 
 """ Simplices of given dimension in a simplicial set.
 """
-@inline simplices(n::Int, s::HasDeltaSet) = 1:nsimplices(Val{n}, s)
+@inline simplices(n::Int, s::HasDeltaSet) = 1:nsimplices(Val(n), s)
 
 """ Number of simplices of given dimension in a simplicial set.
 """
-@inline nsimplices(n::Int, s::HasDeltaSet) = nsimplices(Val{n}, s)
+@inline nsimplices(n::Int, s::HasDeltaSet) = nsimplices(Val(n), s)
 
 """ Face map and boundary operator on simplicial sets.
 
@@ -705,22 +705,22 @@ Note that the face map returns *simplices*, while the boundary operator returns
 *chains* (vectors in the free vector space spanned by oriented simplices).
 """
 @inline ∂(i::Int, s::HasDeltaSet, x::Simplex{n}) where n =
-  Simplex{n-1}(face(Val{(n,i)}, s, x.data))
+  Simplex{n-1}(face(Val(n, Val(i), s, x.data)))
 @inline ∂(n::Int, i::Int, s::HasDeltaSet, args...) =
-  face(Val{(n,i)}, s, args...)
+  face(Val(n), Val(i), s, args...)
 
 @inline coface(i::Int, s::HasDeltaSet, x::Simplex{n}) where n =
-  Simplex{n+1}(coface(Val{(n+1,i)}, s, x.data))
+  Simplex{n+1}(coface(Val(n+1), Val(i), s, x.data))
 @inline coface(n::Int, i::Int, s::HasDeltaSet, args...) =
-  coface(Val{(n,i)}, s, args...)
+  coface(Val(n), Val(i), s, args...)
 
 ∂(s::HasDeltaSet, x::SimplexChain{n}) where n =
-  SimplexChain{n-1}(∂(Val{n}, s, x.data))
-@inline ∂(n::Int, s::HasDeltaSet, args...) = ∂(Val{n}, s, args...)
+  SimplexChain{n-1}(∂(Val(n), s, x.data))
+@inline ∂(n::Int, s::HasDeltaSet, args...) = ∂(Val(n), s, args...)
 
-function ∂(::Type{Val{n}}, s::HasDeltaSet, args...) where n
+function ∂(::Val{n}, s::HasDeltaSet, args...) where n
   operator_nz(Int, nsimplices(n-1,s), nsimplices(n,s), args...) do x
-    ∂_nz(Val{n}, s, x)
+    ∂_nz(Val(n), s, x)
   end
 end
 
@@ -731,12 +731,12 @@ const boundary = ∂
 """ The discrete exterior derivative, aka the coboundary operator.
 """
 d(s::HasDeltaSet, x::SimplexForm{n}) where n =
-  SimplexForm{n+1}(d(Val{n}, s, x.data))
-@inline d(n::Int, s::HasDeltaSet, args...) = d(Val{n}, s, args...)
+  SimplexForm{n+1}(d(Val(n), s, x.data))
+@inline d(n::Int, s::HasDeltaSet, args...) = d(Val(n), s, args...)
 
-function d(::Type{Val{n}}, s::HasDeltaSet, args...) where n
+function d(::Val{n}, s::HasDeltaSet, args...) where n
   operator_nz(Int, nsimplices(n+1,s), nsimplices(n,s), args...) do x
-    d_nz(Val{n}, s, x)
+    d_nz(Val(n), s, x)
   end
 end
 
@@ -751,13 +751,13 @@ const exterior_derivative = d
 """ Orientation of simplex.
 """
 orientation(s::HasDeltaSet, x::Simplex{n}) where n =
-  orientation(Val{n}, s, x.data)
+  orientation(Val(n), s, x.data)
 @inline orientation(n::Int, s::HasDeltaSet, args...) =
-  orientation(Val{n}, s, args...)
+  orientation(Val(n), s, args...)
 
-@inline Base.sign(n::Int, s::HasDeltaSet, args...) = sign(Val{n}, s, args...)
-Base.sign(::Type{Val{n}}, s::HasDeltaSet, args...) where n =
-  numeric_sign.(orientation(Val{n}, s, args...))
+@inline Base.sign(n::Int, s::HasDeltaSet, args...) = sign(Val(n), s, args...)
+Base.sign(::Val{n}, s::HasDeltaSet, args...) where n =
+  numeric_sign.(orientation(Val(n), s, args...))
 
 numeric_sign(x) = sign(x)
 numeric_sign(x::Bool) = x ? +1 : -1
@@ -765,13 +765,13 @@ numeric_sign(x::Bool) = x ? +1 : -1
 """ Set orientation of simplex.
 """
 @inline set_orientation!(n::Int, s::HasDeltaSet, args...) =
-  set_orientation!(Val{n}, s, args...)
+  set_orientation!(Val(n), s, args...)
 
 """ ``n``-dimensional volume of ``n``-simplex in an embedded simplicial set.
 """
 volume(s::HasDeltaSet, x::Simplex{n}, args...) where n =
-  volume(Val{n}, s, x.data, args...)
-@inline volume(n::Int, s::HasDeltaSet, args...) = volume(Val{n}, s, args...)
+  volume(Val(n), s, x.data, args...)
+@inline volume(n::Int, s::HasDeltaSet, args...) = volume(Val(n), s, args...)
 
 """ Convenience function for linear operator based on structural nonzero values.
 """
@@ -793,11 +793,11 @@ orient all simplices of a given dimension and returns whether this has been
 achieved. Each connected component is oriently independently using the helper
 function [`orient_component!`](@ref).
 """
-orient!(s::AbstractDeltaSet1D) = orient!(s, E)
-orient!(s::AbstractDeltaSet2D) = orient!(s, Tri)
-orient!(s::AbstractDeltaSet3D) = orient!(s, Tet)
+orient!(s::AbstractDeltaSet1D) = orient!(s, Val(1))
+orient!(s::AbstractDeltaSet2D) = orient!(s, Val(2))
+orient!(s::AbstractDeltaSet3D) = orient!(s, Val(3))
 
-function orient!(s::HasDeltaSet, ::Type{Simplex{n}}) where n
+function orient!(s::HasDeltaSet, ::Val{n}) where n
   # Compute connected components as coequalizer of face maps.
   ndom, ncodom = nsimplices(n, s), nsimplices(n-1, s)
   face_maps = [ FinFunction(x -> ∂(n,i,s,x), FinSet(ndom), FinSet(ncodom))
@@ -813,7 +813,8 @@ function orient!(s::HasDeltaSet, ::Type{Simplex{n}}) where n
   # Orient each component, starting at the chosen representative.
   init_orientation = one(attrtype_type(s, :Orientation))
   for x in reps
-    orient_component!(s, Simplex{n}(x), init_orientation) || return false
+    #orient_component!(s, Simplex{n}(x), init_orientation) || return false
+    orient_component!(Val(n), s, x, init_orientation) || return false
   end
   true
 end
@@ -830,19 +831,21 @@ If the simplicial set is not connected, the function [`orient!`](@ref) may be
 more convenient.
 """
 orient_component!(s::AbstractDeltaSet1D, e::Int, args...) =
-  orient_component!(s, E(e), args...)
+  orient_component!(Val(1), s, e, args...)
 orient_component!(s::AbstractDeltaSet2D, t::Int, args...) =
-  orient_component!(s, Tri(t), args...)
-orient_component!(s::AbstractDeltaSet3D, t::Int, args...) =
-  orient_component!(s, Tet(t), args...)
+  orient_component!(Val(2), s, t, args...)
+orient_component!(s::AbstractDeltaSet3D, tet::Int, args...) =
+  orient_component!(Val(3), s, tet, args...)
 
-function orient_component!(s::HasDeltaSet, x::Simplex{n},
+function orient_component!(::Val{n}, s::HasDeltaSet, x,
                            x_orientation::Orientation) where {n, Orientation}
   orientations = repeat(Union{Orientation,Nothing}[nothing], nsimplices(n, s))
 
   orient_stack = Vector{Pair{Int64, Orientation}}()
 
-  push!(orient_stack, x[] => x_orientation)
+  # TODO: Make this an Int32 or Int.
+  #push!(orient_stack, Int64[] => x_orientation)
+  push!(orient_stack, x => x_orientation)
   is_orientable = true
   while !isempty(orient_stack)
     x, target = pop!(orient_stack)
@@ -932,7 +935,7 @@ is_manifold_like(s::AbstractDeltaSet1D) = is_manifold_like(s, E)
 is_manifold_like(s::AbstractDeltaSet2D) = is_manifold_like(s, Tri)
 is_manifold_like(s::AbstractDeltaSet3D) = is_manifold_like(s, Tet)
 
-function is_manifold_like(s::HasDeltaSet, ::Type{Simplex{n}}) where n
+function is_manifold_like(s::HasDeltaSet, ::Simplex{n}) where n
   # The yth k-simplex c is not a face of an (k+1)-simplex if the yth column of
   # the exterior derivative matrix is all zeros.
   foreach(0:n-1) do k
@@ -956,7 +959,7 @@ nonboundaries(s::AbstractDeltaSet1D) = nonboundaries(s, E)
 nonboundaries(s::AbstractDeltaSet2D) = nonboundaries(s, Tri)
 nonboundaries(s::AbstractDeltaSet3D) = nonboundaries(s, Tet)
 
-function nonboundaries(s::HasDeltaSet, ::Type{Simplex{n}}) where n
+function nonboundaries(s::HasDeltaSet, ::Simplex{n}) where n
   # The yth k-simplex c is not a face of an (k+1)-simplex if the yth column of
   # the exterior derivative matrix is all zeros.
   map(0:n-1) do k
@@ -988,7 +991,7 @@ This is not the Hodge star [`⋆`](@ref).
 
 See also [`closed_star`](@ref), [`link`](@ref).
 """
-function star(s::HasDeltaSet, v::Int, ::Type{Simplex{n}}) where n
+function star(s::HasDeltaSet, v::Int, ::Simplex{n}) where n
   # Recursively compute cofaces, incrementing dimension.
   cofaces_1n = accumulate(1:n; init=[v]) do c, p
     Simplex{p}(union([Iterators.flatten(coface(p,i,s,c)) for i in 0:p]...))
@@ -1017,7 +1020,7 @@ This is not the Hodge star [`⋆`](@ref).
 
 See also [`star`](@ref), [`link`](@ref).
 """
-function closed_star(s::HasDeltaSet, v::Int, Sts::AbstractVector, ::Type{Simplex{n}}) where n
+function closed_star(s::HasDeltaSet, v::Int, Sts::AbstractVector, ::Simplex{n}) where n
   faces_0nminus1 = map(1:n, Sts, Sts[begin+1:end]) do p, cₚ, cₚ₊₁
     Simplex{p-1}(union(cₚ, [∂(p,i,s,cₚ₊₁) for i in 0:p]...))
   end
@@ -1043,7 +1046,7 @@ of v.
 
 See also [`star`](@ref), [`closed_star`](@ref).
 """
-function link(s::HasDeltaSet, v::Int, ::Type{Simplex{n}}) where n
+function link(s::HasDeltaSet, v::Int, ::Simplex{n}) where n
   map(0:n, closed_star(s,v), star(s,v)) do i, closed, interior
     Simplex{i}(setdiff(closed, interior))
   end
@@ -1053,37 +1056,37 @@ end
 """
 Lk = link
 
-function boundary_inds(::Type{Val{0}}, s::HasDeltaSet1D)
+function boundary_inds(::Val{0}, s::HasDeltaSet1D)
   findall(x -> x < 2, counts(vcat(s[:∂v0], s[:∂v1])))
 end
 
-function boundary_inds(::Type{Val{1}}, s::HasDeltaSet1D)
-  mapreduce(v -> star(s, v)[2], vcat, boundary_inds(Val{0}, s), init=Int64[])
+function boundary_inds(::Val{1}, s::HasDeltaSet1D)
+  mapreduce(v -> star(s, v)[2], vcat, boundary_inds(Val(0), s), init=Int64[])
 end
 
-function boundary_inds(::Type{Val{0}}, s::HasDeltaSet2D)
-  ∂1_inds = boundary_inds(Val{1}, s)
+function boundary_inds(::Val{0}, s::HasDeltaSet2D)
+  ∂1_inds = boundary_inds(Val(1), s)
   unique(vcat(s[∂1_inds,:∂v0],s[∂1_inds,:∂v1]))
 end
 
-function boundary_inds(::Type{Val{1}}, s::HasDeltaSet2D)
-  collect(findall(x -> x != 0, boundary(Val{2},s) * fill(1,ntriangles(s))))
+function boundary_inds(::Val{1}, s::HasDeltaSet2D)
+  collect(findall(x -> x != 0, boundary(Val(2),s) * fill(1,ntriangles(s))))
 end
 
-function boundary_inds(::Type{Val{2}}, s::HasDeltaSet2D)
-  ∂1_inds = boundary_inds(Val{1}, s)
+function boundary_inds(::Val{2}, s::HasDeltaSet2D)
+  ∂1_inds = boundary_inds(Val(1), s)
   inds = map([:∂e0, :∂e1, :∂e2]) do esym
     vcat(incident(s, ∂1_inds, esym)...)
   end
   unique(vcat(inds...))
 end
 
-function interior(::Type{Val{0}}, s::HasDeltaSet2D)
-  boundaries = boundary_inds(Val{0}, s)
+function interior(::Val{0}, s::HasDeltaSet2D)
+  boundaries = boundary_inds(Val(0), s)
   setdiff(vertices(s), boundaries)
 end
 
-function boundary_inds(::Type{Val{3}}, s::HasDeltaSet3D)
+function boundary_inds(::Val{3}, s::HasDeltaSet3D)
   # A tetrahedron is on the boundary if any of its triangles a face of that tetrahedron alone.
   filter(tetrahedra(s)) do tet
     tris = tetrahedron_triangles(s, tet)

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -1083,7 +1083,7 @@ function boundary_inds(::Val{0}, s::HasDeltaSet2D)
 end
 
 function boundary_inds(::Val{1}, s::HasDeltaSet2D)
-  collect(findall(x -> x != 0, boundary(Val(2),s) * fill(1,ntriangles(s))))
+  Base.collect(findall(x -> x != 0, boundary(Val(2),s) * fill(1,ntriangles(s))))
 end
 
 function boundary_inds(::Val{2}, s::HasDeltaSet2D)

--- a/src/SimplicialSets.jl
+++ b/src/SimplicialSets.jl
@@ -705,7 +705,7 @@ Note that the face map returns *simplices*, while the boundary operator returns
 *chains* (vectors in the free vector space spanned by oriented simplices).
 """
 @inline ∂(i::Int, s::HasDeltaSet, x::Simplex{n}) where n =
-  Simplex{n-1}(face(Val(n, Val(i), s, x.data)))
+  Simplex{n-1}(face(Val(n), Val(i), s, x.data))
 @inline ∂(n::Int, i::Int, s::HasDeltaSet, args...) =
   face(Val(n), Val(i), s, args...)
 
@@ -789,6 +789,15 @@ orient!(s::AbstractDeltaSet1D) = orient!(s, Val(1))
 orient!(s::AbstractDeltaSet2D) = orient!(s, Val(2))
 orient!(s::AbstractDeltaSet3D) = orient!(s, Val(3))
 
+# Recall that the boundary of an n-simplex is an *alternating* sum of
+# its faces.
+# When two n-simplices share an (n-1)-simplex, they are like-oriented
+# when the shared simplex face is even (∂₀, ∂₂, ...) for one and odd
+# (∂₁, ∂₃, ...) for the other.
+# Why? Roughly, when you integrate across the shared edge during an application
+# of Stokes' rule, the 2 integrals cancel. If it is not the case that these
+# subscripts are of opposite parity already, we amend matters by flipping the
+# orientation flag of one of them.
 """    function orient!(s::HasDeltaSet, ::Val{n}) where n
 
 Consistently orient simplices in the same connected component, if possible.
@@ -803,14 +812,13 @@ assigned; otherwise, it returns `false` and no orientations are changed.
 function orient!(s::HasDeltaSet, ::Val{n}) where n
   # Empty delta sets are oriented by definition.
   nsimplices(n, s) == 0 && return true
-  neighbors(x) = (coface(n, j, s, ∂(n, i, s, x)) for i in 0:n for j in 0:n)
 
   # Perform DFS.
-  ors = zeros(Int8, nsimplices(n, s)) # (-1, 0, 1)::(negative, visited, positive)
+  ors = zeros(Int8, nsimplices(n, s)) #(-1, 0, 1)::(negative, visited, positive)
   stack = Int[]
   for seed in simplices(n, s)
     @inbounds ors[seed] != 0 && continue
-    empty!(stack) # Invariant.
+    empty!(stack) #Invariant.
     push!(stack, seed)
     @inbounds ors[seed] = 1
     while !isempty(stack)
@@ -820,14 +828,16 @@ function orient!(s::HasDeltaSet, ::Val{n}) where n
       for i in 0:n
         face = ∂(n, i, s, x)
         for j in 0:n
-          y = coface(n, j, s, face)
-          y == x && continue
-          oy = ors[y]
-          if oy == 0
-            @inbounds ors[y] = nox
-            push!(stack, y)
-          elseif oy == ox
-            return false
+          same_parity = iseven(i+j)
+          for y in coface(n, j, s, face)
+            y == x && continue
+            oy = ors[y]
+            if oy == 0
+              @inbounds ors[y] = same_parity ? nox : ox
+              push!(stack, y)
+            elseif same_parity && oy == ox
+              return false
+            end
           end
         end
       end
@@ -934,9 +944,9 @@ two triangles that share 2 vertices share an edge. Nor does it test that e.g.
 there is at most one triangle that connects 3 vertices. Nor does it test that
 the delta set consists of a single component.
 """
-is_manifold_like(s::AbstractDeltaSet1D) = is_manifold_like(s, E)
-is_manifold_like(s::AbstractDeltaSet2D) = is_manifold_like(s, Tri)
-is_manifold_like(s::AbstractDeltaSet3D) = is_manifold_like(s, Tet)
+is_manifold_like(s::AbstractDeltaSet1D) = is_manifold_like(s, E(0))
+is_manifold_like(s::AbstractDeltaSet2D) = is_manifold_like(s, Tri(0))
+is_manifold_like(s::AbstractDeltaSet3D) = is_manifold_like(s, Tet(0))
 
 function is_manifold_like(s::HasDeltaSet, ::Simplex{n}) where n
   # The yth k-simplex c is not a face of an (k+1)-simplex if the yth column of
@@ -958,9 +968,9 @@ We choose the term "nonboundaries" so as not to be confused with the term
 "nonface", defined as those faces that are not in a simplical complex, whose
 corresponding monomials are the basis of the Stanley-Reisner ideal.
 """
-nonboundaries(s::AbstractDeltaSet1D) = nonboundaries(s, E)
-nonboundaries(s::AbstractDeltaSet2D) = nonboundaries(s, Tri)
-nonboundaries(s::AbstractDeltaSet3D) = nonboundaries(s, Tet)
+nonboundaries(s::AbstractDeltaSet1D) = nonboundaries(s, E(0))
+nonboundaries(s::AbstractDeltaSet2D) = nonboundaries(s, Tri(0))
+nonboundaries(s::AbstractDeltaSet3D) = nonboundaries(s, Tet(0))
 
 function nonboundaries(s::HasDeltaSet, ::Simplex{n}) where n
   # The yth k-simplex c is not a face of an (k+1)-simplex if the yth column of
@@ -973,9 +983,9 @@ end
 # Topological helper functions
 ##############################
 
-star(s::AbstractDeltaSet1D, v::Int) = star(s, v, E)
-star(s::AbstractDeltaSet2D, v::Int) = star(s, v, Tri)
-star(s::AbstractDeltaSet3D, v::Int) = star(s, v, Tet)
+star(s::AbstractDeltaSet1D, v::Int) = star(s, v, E(0))
+star(s::AbstractDeltaSet2D, v::Int) = star(s, v, Tri(0))
+star(s::AbstractDeltaSet3D, v::Int) = star(s, v, Tet(0))
 
 """ Star of a vertex in a delta set.
 
@@ -1006,9 +1016,9 @@ end
 """
 St = star
 
-closed_star(s::AbstractDeltaSet1D, v::Int) = closed_star(s, v, star(s, v), E)
-closed_star(s::AbstractDeltaSet2D, v::Int) = closed_star(s, v, star(s, v), Tri)
-closed_star(s::AbstractDeltaSet3D, v::Int) = closed_star(s, v, star(s, v), Tet)
+closed_star(s::AbstractDeltaSet1D, v::Int) = closed_star(s, v, star(s, v), E(0))
+closed_star(s::AbstractDeltaSet2D, v::Int) = closed_star(s, v, star(s, v), Tri(0))
+closed_star(s::AbstractDeltaSet3D, v::Int) = closed_star(s, v, star(s, v), Tet(0))
 
 """ Closed star of a vertex in a delta set.
 
@@ -1034,9 +1044,9 @@ end
 """
 St̄ = closed_star
 
-link(s::AbstractDeltaSet1D, v::Int) = link(s, v, E)
-link(s::AbstractDeltaSet2D, v::Int) = link(s, v, Tri)
-link(s::AbstractDeltaSet3D, v::Int) = link(s, v, Tet)
+link(s::AbstractDeltaSet1D, v::Int) = link(s, v, E(0))
+link(s::AbstractDeltaSet2D, v::Int) = link(s, v, Tri(0))
+link(s::AbstractDeltaSet3D, v::Int) = link(s, v, Tet(0))
 
 """ Link of a vertex in a delta set.
 

--- a/test/Backends.jl
+++ b/test/Backends.jl
@@ -59,7 +59,7 @@ dual_meshes_2D_circum = map(x -> generate_dual(x, Circumcenter()), [
 # Operator Test Definitions
 #--------------------------
 
-function test_unary_operators()
+function test_unary_operators(backend)
   function all_are_equal(cpu_ans::SparseMatrixCSC, alt_ans)
     KernelAbstractions.synchronize(get_backend(alt_ans))
     all(cpu_ans .== SparseMatrixCSC(alt_ans))
@@ -72,13 +72,13 @@ function test_unary_operators()
 
   function test_cpu_gpu_equality(meshes, degrees, operator)
     for (n, sd) in Iterators.product(degrees, meshes)
-      @test all_are_equal(operator(n, sd), operator(n, sd))
+      @test all_are_equal(operator(n, sd), operator(n, sd, backend))
     end
   end
 
   function test_cpu_gpu_equality(meshes, degrees, operator, hodge::DiscreteHodge)
     for (n, sd) in Iterators.product(degrees, meshes)
-      @test all_are_equal(operator(n, sd, hodge), operator(n, sd, hodge))
+      @test all_are_equal(operator(n, sd, hodge), operator(n, sd, hodge, backend))
     end
   end
 
@@ -119,43 +119,43 @@ function test_hodge_solver()
       cuV_1 = CuArray(V_1)
       @test all(isapprox.(
         dec_inv_hodge_star(1, sd, GeometricHodge())(V_1),
-        Array(dec_inv_hodge_star(1, sd, GeometricHodge())(cuV_1));
+        Array(dec_inv_hodge_star(1, sd, GeometricHodge(), Val(:CUDA))(cuV_1));
         atol = 1e-10))
     end
   end
 end
 
-function test_binary_operators(float_type, arr_cons, tol)
+function test_binary_operators(float_type, backend, arr_cons, tol)
   function mse(x,y)
     KernelAbstractions.synchronize(get_backend(y))
     mean(map(z -> z^2, Array(x) .- y)) < tol
   end
 
   @testset "Wedge Product" begin
-    function test_wedge_1D(sd)
+    function test_wedge_1D(sd, backend)
       V1, V2, E1 = rand.(float_type, [nv(sd), nv(sd), ne(sd)])
       altV1, altV2, altE1 = arr_cons.([V1, V2, E1])
 
-      wdg00 = dec_wedge_product(0, 0, sd, arr_cons, float_type)
-      wdg01 = dec_wedge_product(0, 1, sd, arr_cons, float_type)
-      wdg10 = dec_wedge_product(1, 0, sd, arr_cons, float_type)
+      wdg00 = dec_wedge_product(0, 0, sd, backend, arr_cons, float_type)
+      wdg01 = dec_wedge_product(0, 1, sd, backend, arr_cons, float_type)
+      wdg10 = dec_wedge_product(1, 0, sd, backend, arr_cons, float_type)
 
       @test mse(wdg00(altV1, altV2), ∧(0, 0, sd, V1, V2))
       @test mse(wdg01(altV1, altE1), ∧(0, 1, sd, V1, E1))
       @test mse(wdg10(altE1, altV1), ∧(1, 0, sd, E1, V1))
     end
 
-    function test_wedge_2D(sd)
+    function test_wedge_2D(sd, backend)
       V1, V2, E1, E2, T1 = rand.(float_type, [nv(sd), nv(sd), ne(sd), ne(sd), ntriangles(sd)])
       altV1, altV2, altE1, altE2, altT1 = arr_cons.([V1, V2, E1, E2, T1])
       V_ones, E_ones = ones(float_type, nv(sd)), ones(float_type, ne(sd))
       altV_ones, altE_ones = arr_cons.([V_ones, E_ones])
 
-      wdg00 = dec_wedge_product(0, 0, sd, arr_cons, float_type)
-      wdg01 = dec_wedge_product(0, 1, sd, arr_cons, float_type)
-      wdg10 = dec_wedge_product(1, 0, sd, arr_cons, float_type)
-      wdg11 = dec_wedge_product(1, 1, sd, arr_cons, float_type)
-      wdg02 = dec_wedge_product(0, 2, sd, arr_cons, float_type)
+      wdg00 = dec_wedge_product(0, 0, sd, backend, arr_cons, float_type)
+      wdg01 = dec_wedge_product(0, 1, sd, backend, arr_cons, float_type)
+      wdg10 = dec_wedge_product(1, 0, sd, backend, arr_cons, float_type)
+      wdg11 = dec_wedge_product(1, 1, sd, backend, arr_cons, float_type)
+      wdg02 = dec_wedge_product(0, 2, sd, backend, arr_cons, float_type)
 
       @test mse(wdg01(altV_ones, altE_ones), E_ones)
       @test mse(wdg00(altV1, altV2), ∧(0, 0, sd, V1, V2))
@@ -166,10 +166,10 @@ function test_binary_operators(float_type, arr_cons, tol)
     end
 
     for sd in dual_meshes_1D
-      test_wedge_1D(sd)
+      test_wedge_1D(sd, backend)
     end
     for sd in dual_meshes_2D_bary
-      test_wedge_2D(sd)
+      test_wedge_2D(sd, backend)
     end
   end
 end
@@ -179,16 +179,16 @@ end
 
 # Test that Float32s pass through correctly.
 @testset "Float32 Operators" begin
-  test_binary_operators(Float32, Array, 1e-15)
+  test_binary_operators(Float32, Val(:CPU), Array, 1e-15)
 end
 
 using CUDA
 if CUDA.functional()
   @testset "CUDA" begin
-    test_unary_operators()
+    test_unary_operators(Val(:CUDA))
     test_hodge_solver()
-    test_binary_operators(Float64, CuArray, 1e-15)
-    test_binary_operators(Float32, CuArray, 1e-15)
+    test_binary_operators(Float64, Val(:CUDA), CuArray, 1e-15)
+    test_binary_operators(Float32, Val(:CUDA), CuArray, 1e-15)
   end
 else
   # Get the short error description instead of full stacktrace
@@ -207,8 +207,8 @@ if Sys.isapple()
   dev = Metal.device()
   if Metal.supports_family(dev, Metal.MTL.MTLGPUFamilyApple7) && Metal.supports_family(dev, Metal.MTL.MTLGPUFamilyMetal3)
     @testset "Metal" begin
-      test_binary_operators(Float32, MtlArray, 0.5e-6)
-      test_binary_operators(Float16, MtlArray, 0.5e-3)
+      test_binary_operators(Float32, Val(:Metal), MtlArray, 0.5e-6)
+      test_binary_operators(Float16, Val(:Metal), MtlArray, 0.5e-3)
     end
   else
     @info "Metal tests were not run, since the current device does not support Apple7 and Metal3."

--- a/test/Backends.jl
+++ b/test/Backends.jl
@@ -59,7 +59,7 @@ dual_meshes_2D_circum = map(x -> generate_dual(x, Circumcenter()), [
 # Operator Test Definitions
 #--------------------------
 
-function test_unary_operators(backend)
+function test_unary_operators()
   function all_are_equal(cpu_ans::SparseMatrixCSC, alt_ans)
     KernelAbstractions.synchronize(get_backend(alt_ans))
     all(cpu_ans .== SparseMatrixCSC(alt_ans))
@@ -72,13 +72,13 @@ function test_unary_operators(backend)
 
   function test_cpu_gpu_equality(meshes, degrees, operator)
     for (n, sd) in Iterators.product(degrees, meshes)
-      @test all_are_equal(operator(n, sd), operator(n, sd, backend))
+      @test all_are_equal(operator(n, sd), operator(n, sd))
     end
   end
 
   function test_cpu_gpu_equality(meshes, degrees, operator, hodge::DiscreteHodge)
     for (n, sd) in Iterators.product(degrees, meshes)
-      @test all_are_equal(operator(n, sd, hodge), operator(n, sd, hodge, backend))
+      @test all_are_equal(operator(n, sd, hodge), operator(n, sd, hodge))
     end
   end
 
@@ -119,43 +119,43 @@ function test_hodge_solver()
       cuV_1 = CuArray(V_1)
       @test all(isapprox.(
         dec_inv_hodge_star(1, sd, GeometricHodge())(V_1),
-        Array(dec_inv_hodge_star(1, sd, GeometricHodge(), Val{:CUDA})(cuV_1));
+        Array(dec_inv_hodge_star(1, sd, GeometricHodge())(cuV_1));
         atol = 1e-10))
     end
   end
 end
 
-function test_binary_operators(float_type, backend, arr_cons, tol)
+function test_binary_operators(float_type, arr_cons, tol)
   function mse(x,y)
     KernelAbstractions.synchronize(get_backend(y))
     mean(map(z -> z^2, Array(x) .- y)) < tol
   end
 
   @testset "Wedge Product" begin
-    function test_wedge_1D(sd, backend)
+    function test_wedge_1D(sd)
       V1, V2, E1 = rand.(float_type, [nv(sd), nv(sd), ne(sd)])
       altV1, altV2, altE1 = arr_cons.([V1, V2, E1])
 
-      wdg00 = dec_wedge_product(0, 0, sd, backend, arr_cons, float_type)
-      wdg01 = dec_wedge_product(0, 1, sd, backend, arr_cons, float_type)
-      wdg10 = dec_wedge_product(1, 0, sd, backend, arr_cons, float_type)
+      wdg00 = dec_wedge_product(0, 0, sd, arr_cons, float_type)
+      wdg01 = dec_wedge_product(0, 1, sd, arr_cons, float_type)
+      wdg10 = dec_wedge_product(1, 0, sd, arr_cons, float_type)
 
       @test mse(wdg00(altV1, altV2), ∧(0, 0, sd, V1, V2))
       @test mse(wdg01(altV1, altE1), ∧(0, 1, sd, V1, E1))
       @test mse(wdg10(altE1, altV1), ∧(1, 0, sd, E1, V1))
     end
 
-    function test_wedge_2D(sd, backend)
+    function test_wedge_2D(sd)
       V1, V2, E1, E2, T1 = rand.(float_type, [nv(sd), nv(sd), ne(sd), ne(sd), ntriangles(sd)])
       altV1, altV2, altE1, altE2, altT1 = arr_cons.([V1, V2, E1, E2, T1])
       V_ones, E_ones = ones(float_type, nv(sd)), ones(float_type, ne(sd))
       altV_ones, altE_ones = arr_cons.([V_ones, E_ones])
 
-      wdg00 = dec_wedge_product(0, 0, sd, backend, arr_cons, float_type)
-      wdg01 = dec_wedge_product(0, 1, sd, backend, arr_cons, float_type)
-      wdg10 = dec_wedge_product(1, 0, sd, backend, arr_cons, float_type)
-      wdg11 = dec_wedge_product(1, 1, sd, backend, arr_cons, float_type)
-      wdg02 = dec_wedge_product(0, 2, sd, backend, arr_cons, float_type)
+      wdg00 = dec_wedge_product(0, 0, sd, arr_cons, float_type)
+      wdg01 = dec_wedge_product(0, 1, sd, arr_cons, float_type)
+      wdg10 = dec_wedge_product(1, 0, sd, arr_cons, float_type)
+      wdg11 = dec_wedge_product(1, 1, sd, arr_cons, float_type)
+      wdg02 = dec_wedge_product(0, 2, sd, arr_cons, float_type)
 
       @test mse(wdg01(altV_ones, altE_ones), E_ones)
       @test mse(wdg00(altV1, altV2), ∧(0, 0, sd, V1, V2))
@@ -166,10 +166,10 @@ function test_binary_operators(float_type, backend, arr_cons, tol)
     end
 
     for sd in dual_meshes_1D
-      test_wedge_1D(sd, backend)
+      test_wedge_1D(sd)
     end
     for sd in dual_meshes_2D_bary
-      test_wedge_2D(sd, backend)
+      test_wedge_2D(sd)
     end
   end
 end
@@ -179,16 +179,16 @@ end
 
 # Test that Float32s pass through correctly.
 @testset "Float32 Operators" begin
-  test_binary_operators(Float32, Val{:CPU}, Array, 1e-15)
+  test_binary_operators(Float32, Array, 1e-15)
 end
 
 using CUDA
 if CUDA.functional()
   @testset "CUDA" begin
-    test_unary_operators(Val{:CUDA})
+    test_unary_operators()
     test_hodge_solver()
-    test_binary_operators(Float64, Val{:CUDA}, CuArray, 1e-15)
-    test_binary_operators(Float32, Val{:CUDA}, CuArray, 1e-15)
+    test_binary_operators(Float64, CuArray, 1e-15)
+    test_binary_operators(Float32, CuArray, 1e-15)
   end
 else
   # Get the short error description instead of full stacktrace
@@ -207,8 +207,8 @@ if Sys.isapple()
   dev = Metal.device()
   if Metal.supports_family(dev, Metal.MTL.MTLGPUFamilyApple7) && Metal.supports_family(dev, Metal.MTL.MTLGPUFamilyMetal3)
     @testset "Metal" begin
-      test_binary_operators(Float32, Val{:Metal}, MtlArray, 0.5e-6)
-      test_binary_operators(Float16, Val{:Metal}, MtlArray, 0.5e-3)
+      test_binary_operators(Float32, MtlArray, 0.5e-6)
+      test_binary_operators(Float16, MtlArray, 0.5e-3)
     end
   else
     @info "Metal tests were not run, since the current device does not support Apple7 and Metal3."
@@ -218,3 +218,4 @@ else
 end
 
 end
+

--- a/test/Backends.jl
+++ b/test/Backends.jl
@@ -118,8 +118,8 @@ function test_hodge_solver()
       V_1 = Float64.(I[1:ne(sd), 1])
       cuV_1 = CuArray(V_1)
       @test all(isapprox.(
-        dec_inv_hodge_star(Val{1}, sd, GeometricHodge())(V_1),
-        Array(dec_inv_hodge_star(Val{1}, sd, GeometricHodge(), Val{:CUDA})(cuV_1));
+        dec_inv_hodge_star(1, sd, GeometricHodge())(V_1),
+        Array(dec_inv_hodge_star(1, sd, GeometricHodge(), Val{:CUDA})(cuV_1));
         atol = 1e-10))
     end
   end
@@ -136,13 +136,13 @@ function test_binary_operators(float_type, backend, arr_cons, tol)
       V1, V2, E1 = rand.(float_type, [nv(sd), nv(sd), ne(sd)])
       altV1, altV2, altE1 = arr_cons.([V1, V2, E1])
 
-      wdg00 = dec_wedge_product(Tuple{0,0}, sd, backend, arr_cons, float_type)
-      wdg01 = dec_wedge_product(Tuple{0,1}, sd, backend, arr_cons, float_type)
-      wdg10 = dec_wedge_product(Tuple{1,0}, sd, backend, arr_cons, float_type)
+      wdg00 = dec_wedge_product(0, 0, sd, backend, arr_cons, float_type)
+      wdg01 = dec_wedge_product(0, 1, sd, backend, arr_cons, float_type)
+      wdg10 = dec_wedge_product(1, 0, sd, backend, arr_cons, float_type)
 
-      @test mse(wdg00(altV1, altV2), ∧(Tuple{0,0}, sd, V1, V2))
-      @test mse(wdg01(altV1, altE1), ∧(Tuple{0,1}, sd, V1, E1))
-      @test mse(wdg10(altE1, altV1), ∧(Tuple{1,0}, sd, E1, V1))
+      @test mse(wdg00(altV1, altV2), ∧(0, 0, sd, V1, V2))
+      @test mse(wdg01(altV1, altE1), ∧(0, 1, sd, V1, E1))
+      @test mse(wdg10(altE1, altV1), ∧(1, 0, sd, E1, V1))
     end
 
     function test_wedge_2D(sd, backend)
@@ -151,18 +151,18 @@ function test_binary_operators(float_type, backend, arr_cons, tol)
       V_ones, E_ones = ones(float_type, nv(sd)), ones(float_type, ne(sd))
       altV_ones, altE_ones = arr_cons.([V_ones, E_ones])
 
-      wdg00 = dec_wedge_product(Tuple{0,0}, sd, backend, arr_cons, float_type)
-      wdg01 = dec_wedge_product(Tuple{0,1}, sd, backend, arr_cons, float_type)
-      wdg10 = dec_wedge_product(Tuple{1,0}, sd, backend, arr_cons, float_type)
-      wdg11 = dec_wedge_product(Tuple{1,1}, sd, backend, arr_cons, float_type)
-      wdg02 = dec_wedge_product(Tuple{0,2}, sd, backend, arr_cons, float_type)
+      wdg00 = dec_wedge_product(0, 0, sd, backend, arr_cons, float_type)
+      wdg01 = dec_wedge_product(0, 1, sd, backend, arr_cons, float_type)
+      wdg10 = dec_wedge_product(1, 0, sd, backend, arr_cons, float_type)
+      wdg11 = dec_wedge_product(1, 1, sd, backend, arr_cons, float_type)
+      wdg02 = dec_wedge_product(0, 2, sd, backend, arr_cons, float_type)
 
       @test mse(wdg01(altV_ones, altE_ones), E_ones)
-      @test mse(wdg00(altV1, altV2), ∧(Tuple{0,0}, sd, V1, V2))
-      @test mse(wdg01(altV1, altE2), ∧(Tuple{0,1}, sd, V1, E2))
-      @test mse(wdg10(altE1, altV2), ∧(Tuple{1,0}, sd, E1, V2))
-      @test mse(wdg02(altV1, altT1), ∧(Tuple{0,2}, sd, V1, T1))
-      @test mse(wdg11(altE1, altE2), ∧(Tuple{1,1}, sd, E1, E2))
+      @test mse(wdg00(altV1, altV2), ∧(0, 0, sd, V1, V2))
+      @test mse(wdg01(altV1, altE2), ∧(0, 1, sd, V1, E2))
+      @test mse(wdg10(altE1, altV2), ∧(1, 0, sd, E1, V2))
+      @test mse(wdg02(altV1, altT1), ∧(0, 2, sd, V1, T1))
+      @test mse(wdg11(altE1, altE2), ∧(1, 1, sd, E1, E2))
     end
 
     for sd in dual_meshes_1D

--- a/test/Benchmarks.jl
+++ b/test/Benchmarks.jl
@@ -127,11 +127,11 @@ end
 
 dec_op_results = run(dec_op_suite, verbose = true, seconds = 1)
 
-for op in sort(collect(keys(dec_op_results)))
+for op in sort(Base.collect(keys(dec_op_results)))
     test = median(dec_op_results[op])
 
     println("Operator: $op")
-    for k in sort(collect(keys(test)))
+    for k in sort(Base.collect(keys(test)))
         t = test[k].time / 1e6
         m = test[k].memory / 1e6
         println("Variant: $k, [$t ms, $m MB]")
@@ -167,11 +167,11 @@ end
 
 dual_mesh_results = run(dual_mesh_suite, verbose = true)
 
-for center in sort(collect(keys(dual_mesh_results)))
+for center in sort(Base.collect(keys(dual_mesh_results)))
     trial = median(dual_mesh_results[center][filler_name])
 
     println("Center: $center")
-    for k in sort(collect(keys(trial)), rev=true)
+    for k in sort(Base.collect(keys(trial)), rev=true)
         t = trial[k].time / 1e9
         m = trial[k].memory / 1e9
         println("$k, [$t s, $m GB]")

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -539,7 +539,7 @@ primal_s, s = grid_345();
 # ∀ βᵏ ∧(α,βᵏ) = id(βᵏ), where α = 1.
 α = VForm(ones(nv(s)))
 for k = 0:2
-  βᵏ = SimplexForm{k}(collect(1:nsimplices(k,s)))
+  βᵏ = SimplexForm{k}(Base.collect(1:nsimplices(k,s)))
   @test all(∧(s, α, βᵏ) .≈ βᵏ)
 end
 
@@ -982,7 +982,7 @@ inv_star₃_mat = inv_hodge_star(0,s,DiagonalHodge())
 
 lap_mat = inv_star₃_mat * dual_d₂_mat * star₁_mat * d₀_mat
 
-C = collect(range(1, 4; length=nv(s)))
+C = Base.collect(range(1, 4; length=nv(s)))
 C₀ = copy(C)
 D = 0.005
 for _ in 0:100_000

--- a/test/DiscreteExteriorCalculus.jl
+++ b/test/DiscreteExteriorCalculus.jl
@@ -318,7 +318,8 @@ subdivide_duals!(s, Barycenter())
 # Test consistency regardless of base triangle orientation (relevant for
 # geometric hodge star)
 flipped_ps = deepcopy(primal_s)
-orient_component!(flipped_ps, 1, false)
+orient!(flipped_ps)
+flipped_ps[:tri_orientation] = .!(flipped_ps[:tri_orientation])
 flipped_s = EmbeddedDeltaDualComplex2D{Bool,Float64,Point2d}(flipped_ps)
 subdivide_duals!(flipped_s, Barycenter())
 @test ⋆(1,s) ≈ ⋆(1,flipped_s)
@@ -666,11 +667,11 @@ v = d0 * v_potential; # dy: Ω₁
 u = s1 * d0 * u_potential; # -dy or dy, depending on left vs. right-hand rule: Ω̃₁
 # Only test the interior of the domain. Boundary conditions were not enforced.
 α = dd0 * (interior_product(tg, EForm(v), DualForm{1}(u)))# : Ω̃₁
-α_int = α[setdiff(parts(tg,:E), boundary_inds(Val{1}, tg))]
+α_int = α[setdiff(parts(tg,:E), boundary_inds(Val(1), tg))]
 @test all(x -> isapprox(x,0,atol=1e-14), α_int)
 # Test the Lie derivative (which employs the primal-dual interior product).
-β = lie_derivative_flat(Val{1}, tg, v, u)
-β_int = β[setdiff(parts(tg,:E), boundary_inds(Val{1}, tg))]
+β = lie_derivative_flat(Val(1), tg, v, u)
+β_int = β[setdiff(parts(tg,:E), boundary_inds(Val(1), tg))]
 # Boundary conditions were not enforced.
 @test .85 < sum(map(x -> isapprox(x,0,atol=1e-14), β_int)) / length(β_int)
 
@@ -723,8 +724,8 @@ for (primal_s,s) in flat_ccw_meshes
   # This test shows how the musical isomorphism chaining lets you further
   # define a primal-dual wedge that preserves properties from the continuous
   # exterior calculus.
-  Λpd = dec_wedge_product_pd(Tuple{1,1}, s)
-  Λdp = dec_wedge_product_dp(Tuple{1,1}, s)
+  Λpd = dec_wedge_product_pd(1, 1, s)
+  Λdp = dec_wedge_product_dp(1, 1, s)
 
   f_def = SVector{3,Float64}(2,7,0)
   g_def = SVector{3,Float64}(8,1,0)
@@ -812,7 +813,7 @@ x_interior_points = findall(rect[:point]) do p
   dx < p[1] < lx - dx
 end
 
-interior_points = setdiff(vertices(rect), boundary_inds(Val{0}, rect))
+interior_points = setdiff(vertices(rect), boundary_inds(Val(0), rect))
 
 primal_points = d_rect[:point]
 dual_points = d_rect[triangle_center(d_rect), :dual_point]

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -43,10 +43,18 @@ expected_parts(s, cubic_subdivision, cubic_nv_ne_ntriangles)
 # Subdivision integration
 #------------------------
 
+function fast_laplace_beltrami(sd)
+  -1 * dec_inv_hodge_star(0,sd) * dec_dual_derivative(1,sd) * dec_hodge_star(1,sd) * dec_differential(0,sd)
+end
+
+function fast_laplace_derham(sd)
+  dec_inv_hodge_star(0,sd) * dec_dual_derivative(1,sd) * dec_hodge_star(1,sd) * dec_differential(0,sd)
+end
+
 function test_residuals(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme)
   series = PrimalGeometricMapSeries(s, scheme, 4);
 
-  md = MGData(series, sd -> ∇²(0, sd), 3)
+  md = MGData(series, fast_laplace_beltrami, 3)
   sd = finest_mesh(series)
   L = first(md.operators)
 
@@ -85,8 +93,8 @@ test_residuals(s, CubicSubdivision())
 #---------------------------------
 s = triangulated_grid(1, 1, 1/4, sqrt(3)/2 * 1/4, Point3d, false)
 series = PrimalGeometricMapSeries(s, BinarySubdivision(), 4);
-md_via_series = MGData(series, sd -> ∇²(0, sd), 3)
-md_directly = MultigridData(s, BinarySubdivision(), 4, sd -> ∇²(0, sd), 3)
+md_via_series = MGData(series, fast_laplace_beltrami, 3)
+md_directly = MultigridData(s, BinarySubdivision(), 4, fast_laplace_beltrami, 3)
 
 @test md_directly.operators == md_via_series.operators
 @test md_directly.prolongations == md_via_series.prolongations
@@ -95,10 +103,10 @@ md_directly = MultigridData(s, BinarySubdivision(), 4, sd -> ∇²(0, sd), 3)
 
 md_via_series_allocs = @allocated begin
   series = PrimalGeometricMapSeries(s, BinarySubdivision(), 4);
-  MGData(series, sd -> ∇²(0, sd), 3);
+  MGData(series, fast_laplace_beltrami, 3);
 end;
 md_directly_allocs = @allocated begin
-  MultigridData(s, BinarySubdivision(), 4, sd -> ∇²(0, sd), 3);
+  MultigridData(s, BinarySubdivision(), 4, fast_laplace_beltrami, 3);
 end;
 @test md_directly_allocs < md_via_series_allocs
 
@@ -106,7 +114,7 @@ end;
 #----------------------
 
 function test_galerkin(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme)
-  md = MultigridData(s, scheme, 4, sd -> ∇²(0, sd), 3, galerkin=true)
+  md = MultigridData(s, scheme, 4, fast_laplace_beltrami, 3; mode=GalerkinMode())
   for _ in 1:4
     s = subdivision(s, scheme)
   end
@@ -145,8 +153,8 @@ test_galerkin(s, CubicSubdivision())
 
 s = triangulated_grid(1,1,1/4,sqrt(3)/2*1/4,Point3d,false)
 bin_series = PrimalGeometricMapSeries(s, BinarySubdivision(), 4);
-md_zero_iterations = MGData(bin_series, sd -> ∇²(0, sd), 0)
-md_one_iteration = MGData(bin_series, sd -> ∇²(0, sd), 1)
+md_zero_iterations = MGData(bin_series, fast_laplace_beltrami, 0)
+md_one_iteration = MGData(bin_series, fast_laplace_beltrami, 1)
 sd = finest_mesh(bin_series)
 L = first(md_zero_iterations.operators)
 Random.seed!(0)

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -4,7 +4,7 @@ using Random
 using SparseArrays
 using CombinatorialSpaces.CombMeshes: tri_345
 
-using CombinatorialSpaces.Multigrid: UnarySubdivision, unary_subdivision, unary_subdivision_map
+using CombinatorialSpaces.Multigrid: UnarySubdivision, unary_subdivision, unary_subdivision_map, subdivision
 
 Random.seed!(0)
 
@@ -56,22 +56,22 @@ function test_residuals(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme)
 
   mgv_lapl = dec_Δ⁻¹(Val{0}, series, scheme=scheme)
   u = mgv_lapl(b)
-  @test norm(L*u-b)/norm(b) < 10^-6
+  @test norm(L*u-b)/norm(b) < 1e-6
 
   u = multigrid_vcycles(u0,b,md,5)
-  @test norm(L*u-b)/norm(b) < 10^-7
+  @test norm(L*u-b)/norm(b) < 1e-7
   @debug "Relative residual for V: $(norm(L*u-b)/norm(b))"
 
   u = multigrid_wcycles(u0,b,md,5)
-  @test norm(L*u-b)/norm(b) < 10^-7
+  @test norm(L*u-b)/norm(b) < 1e-7
   @debug "Relative residual for W: $(norm(L*u-b)/norm(b))"
 
   u = full_multigrid(b,md,5)
-  @test norm(L*u-b)/norm(b) < 10^-6
+  @test norm(L*u-b)/norm(b) < 1e-6
   @debug "Relative residual for FMG_V: $(norm(L*u-b)/norm(b))"
 
   u = full_multigrid(b,md,5,cg,2)
-  @test norm(L*u-b)/norm(b) < 10^-7
+  @test norm(L*u-b)/norm(b) < 1e-7
   @debug "Relative residual for FMG_W: $(norm(L*u-b)/norm(b))"
 end
 
@@ -101,6 +101,44 @@ md_directly_allocs = @allocated begin
   MultigridData(s, BinarySubdivision(), 4, sd -> ∇²(0, sd), 3);
 end;
 @test md_directly_allocs < md_via_series_allocs
+
+# Galerkin optimization
+#----------------------
+
+function test_galerkin(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme)
+  md = MultigridData(s, scheme, 4, sd -> ∇²(0, sd), 3, galerkin=true)
+  for _ in 1:4
+    s = subdivision(s, scheme)
+  end
+  sd = dualize(s)
+  L = first(md.operators)
+
+  Random.seed!(0)
+  b = L*rand(nv(sd)) #put into range of the Laplacian for solvability
+  u0 = zeros(nv(sd))
+
+  u = multigrid_vcycles(u0,b,md,5)
+  @test norm(L*u-b)/norm(b) < 2e-6
+  @debug "Relative residual for V: $(norm(L*u-b)/norm(b))"
+
+  u = multigrid_wcycles(u0,b,md,5)
+  @test norm(L*u-b)/norm(b) < 7e-7
+  @debug "Relative residual for W: $(norm(L*u-b)/norm(b))"
+
+  u = full_multigrid(b,md,5)
+  @test norm(L*u-b)/norm(b) < 1e-3
+  @debug "Relative residual for FMG_V: $(norm(L*u-b)/norm(b))"
+
+  u = full_multigrid(b,md,5,cg,2)
+  @test norm(L*u-b)/norm(b) < 8e-7
+  @debug "Relative residual for FMG_W: $(norm(L*u-b)/norm(b))"
+end
+
+s = triangulated_grid(1, 1, 1/4, sqrt(3)/2 * 1/4, Point3d, false)
+
+test_galerkin(s, UnarySubdivision())
+test_galerkin(s, BinarySubdivision())
+test_galerkin(s, CubicSubdivision())
 
 # Divergence from Default Krylov.jl Behavior. (No iterations). Issue #178
 #------------------------------------------------------------------------

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -81,6 +81,27 @@ test_residuals(s, UnarySubdivision())
 test_residuals(s, BinarySubdivision())
 test_residuals(s, CubicSubdivision())
 
+# Equivalence between constructors
+#---------------------------------
+s = triangulated_grid(1, 1, 1/4, sqrt(3)/2 * 1/4, Point3d, false)
+series = PrimalGeometricMapSeries(s, BinarySubdivision(), 4);
+md_via_series = MGData(series, sd -> ∇²(0, sd), 3)
+md_directly = MultigridData(s, BinarySubdivision(), 4, sd -> ∇²(0, sd), 3)
+
+@test md_directly.operators == md_via_series.operators
+@test md_directly.prolongations == md_via_series.prolongations
+@test md_directly.restrictions == md_via_series.restrictions
+@test md_directly.steps == md_via_series.steps
+
+md_via_series_allocs = @allocated begin
+  series = PrimalGeometricMapSeries(s, BinarySubdivision(), 4);
+  MGData(series, sd -> ∇²(0, sd), 3);
+end;
+md_directly_allocs = @allocated begin
+  MultigridData(s, BinarySubdivision(), 4, sd -> ∇²(0, sd), 3);
+end;
+@test md_directly_allocs < md_via_series_allocs
+
 # Divergence from Default Krylov.jl Behavior. (No iterations). Issue #178
 #------------------------------------------------------------------------
 

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -138,7 +138,7 @@ function test_galerkin(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme)
   @debug "Relative residual for FMG_V: $(norm(L*u-b)/norm(b))"
 
   u = full_multigrid(b,md,5,cg,2)
-  @test norm(L*u-b)/norm(b) < 8e-7
+  @test norm(L*u-b)/norm(b) < 9e-7
   @debug "Relative residual for FMG_W: $(norm(L*u-b)/norm(b))"
 end
 

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -59,7 +59,7 @@ function test_residuals(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme)
   L = first(md.operators)
 
   Random.seed!(0)
-  b = L*rand(nv(sd)) #put into range of the Laplacian for solvability
+  b = L*rand(nv(sd))
   u0 = zeros(nv(sd))
 
   mgv_lapl = dec_Δ⁻¹(Val{0}, series, scheme=scheme)
@@ -122,7 +122,7 @@ function test_galerkin(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme)
   L = first(md.operators)
 
   Random.seed!(0)
-  b = L*rand(nv(sd)) #put into range of the Laplacian for solvability
+  b = L*rand(nv(sd))
   u0 = zeros(nv(sd))
 
   u = multigrid_vcycles(u0,b,md,5)
@@ -158,7 +158,7 @@ md_one_iteration = MGData(bin_series, fast_laplace_beltrami, 1)
 sd = finest_mesh(bin_series)
 L = first(md_zero_iterations.operators)
 Random.seed!(0)
-b = L*rand(nv(sd)) #put into range of the Laplacian for solvability
+b = L*rand(nv(sd))
 u0 = zeros(nv(sd))
 u_zero_iterations = multigrid_vcycles(u0,b,md_zero_iterations,5)
 u_one_iteration = multigrid_vcycles(u0,b,md_one_iteration,5)

--- a/test/Multigrid.jl
+++ b/test/Multigrid.jl
@@ -27,7 +27,7 @@ binary_nv_ne_ntriangles(s) =
 cubic_nv_ne_ntriangles(s) =
   (nv(s) + 2*ne(s) + ntriangles(s), 3*ne(s) + 9*ntriangles(s), 9*ntriangles(s))
 
-function expected_parts(s, subdivider, nv_ne_ntriangles)
+function test_expected_parts(s, subdivider, nv_ne_ntriangles)
   for _ in 1:4
     t = subdivider(s)
     @test (nv(t), ne(t), ntriangles(t)) == nv_ne_ntriangles(s)
@@ -36,9 +36,9 @@ function expected_parts(s, subdivider, nv_ne_ntriangles)
   end
 end
 
-expected_parts(s, unary_subdivision, unary_nv_ne_ntriangles)
-expected_parts(s, binary_subdivision, binary_nv_ne_ntriangles)
-expected_parts(s, cubic_subdivision, cubic_nv_ne_ntriangles)
+test_expected_parts(s, unary_subdivision, unary_nv_ne_ntriangles)
+test_expected_parts(s, binary_subdivision, binary_nv_ne_ntriangles)
+test_expected_parts(s, cubic_subdivision, cubic_nv_ne_ntriangles)
 
 # Subdivision integration
 #------------------------
@@ -62,7 +62,7 @@ function test_residuals(s::HasDeltaSet2D, scheme::AbstractSubdivisionScheme)
   b = L*rand(nv(sd))
   u0 = zeros(nv(sd))
 
-  mgv_lapl = dec_Δ⁻¹(Val{0}, series, scheme=scheme)
+  mgv_lapl = dec_Δ⁻¹(Val(0), series, scheme=scheme)
   u = mgv_lapl(b)
   @test norm(L*u-b)/norm(b) < 1e-6
 

--- a/test/Operators.jl
+++ b/test/Operators.jl
@@ -140,19 +140,19 @@ end
 @testset "Diagonal Hodge" begin
     for i in 0:1
         for sd in dual_meshes_1D
-            @test all(isapprox.(dec_hodge_star(Val{i}, sd, DiagonalHodge()), hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_hodge_star(Val(i), sd, DiagonalHodge()), hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
         end
     end
 
     for i in 0:2
         for sd in dual_meshes_2D
-            @test all(isapprox.(dec_hodge_star(Val{i}, sd, DiagonalHodge()), hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_hodge_star(Val(i), sd, DiagonalHodge()), hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
         end
     end
 
     for i in 0:3
         for sd in dual_meshes_3D
-            @test all(isapprox.(dec_hodge_star(Val{i}, sd, DiagonalHodge()), hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_hodge_star(Val(i), sd, DiagonalHodge()), hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
         end
     end
 end
@@ -161,19 +161,19 @@ end
 @testset "Inverse Diagonal Hodge" begin
     for i in 0:1
         for sd in dual_meshes_1D
-            @test all(isapprox.(dec_inv_hodge_star(Val{i}, sd, DiagonalHodge()), inv_hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_inv_hodge_star(Val(i), sd, DiagonalHodge()), inv_hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
         end
     end
 
     for i in 0:2
         for sd in dual_meshes_2D
-            @test all(isapprox.(dec_inv_hodge_star(Val{i}, sd, DiagonalHodge()), inv_hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_inv_hodge_star(Val(i), sd, DiagonalHodge()), inv_hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
         end
     end
 
     for i in 0:3
         for sd in dual_meshes_3D
-            @test all(isapprox.(dec_inv_hodge_star(Val{i}, sd, DiagonalHodge()), inv_hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_inv_hodge_star(Val(i), sd, DiagonalHodge()), inv_hodge_star(i, sd, DiagonalHodge()); rtol = 1e-12))
         end
     end
 end
@@ -181,20 +181,20 @@ end
 @testset "Geometric Hodge" begin
     for i in 0:1
         for sd in dual_meshes_1D
-            @test all(isapprox.(dec_hodge_star(Val{i}, sd, GeometricHodge()), hodge_star(i, sd, GeometricHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_hodge_star(Val(i), sd, GeometricHodge()), hodge_star(i, sd, GeometricHodge()); rtol = 1e-12))
         end
     end
 
     for i in [0, 2]
         for sd in dual_meshes_2D
-            @test all(isapprox.(dec_hodge_star(Val{i}, sd, GeometricHodge()), hodge_star(i, sd, GeometricHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_hodge_star(Val(i), sd, GeometricHodge()), hodge_star(i, sd, GeometricHodge()); rtol = 1e-12))
         end
     end
 
     # TODO: Why does this test require atol, not rtol, to reasonably pass?
     for i in [1]
         for sd in dual_meshes_2D
-            @test all(isapprox.(dec_hodge_star(Val{i}, sd, GeometricHodge()), hodge_star(i, sd, GeometricHodge()); atol = 1e-12))
+            @test all(isapprox.(dec_hodge_star(Val(i), sd, GeometricHodge()), hodge_star(i, sd, GeometricHodge()); atol = 1e-12))
         end
     end
 
@@ -203,20 +203,20 @@ end
 @testset "Inverse Geometric Hodge" begin
     for i in 0:1
         for sd in dual_meshes_1D
-            @test all(isapprox.(dec_inv_hodge_star(Val{i}, sd, GeometricHodge()), inv_hodge_star(i, sd, GeometricHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_inv_hodge_star(Val(i), sd, GeometricHodge()), inv_hodge_star(i, sd, GeometricHodge()); rtol = 1e-12))
         end
     end
 
     for i in [0, 2]
         for sd in dual_meshes_2D
-            @test all(isapprox.(dec_inv_hodge_star(Val{i}, sd, GeometricHodge()), inv_hodge_star(i, sd, GeometricHodge()); rtol = 1e-12))
+            @test all(isapprox.(dec_inv_hodge_star(Val(i), sd, GeometricHodge()), inv_hodge_star(i, sd, GeometricHodge()); rtol = 1e-12))
         end
     end
 
     for i in 1:1
         for sd in dual_meshes_2D[1:end-1]
             V_1 = rand(ne(sd))
-            @test all(isapprox.(dec_inv_hodge_star(Val{i}, sd, GeometricHodge())(V_1), inv_hodge_star(i, sd, GeometricHodge()) * V_1; rtol = 1e-12))
+            @test all(isapprox.(dec_inv_hodge_star(Val(i), sd, GeometricHodge())(V_1), inv_hodge_star(i, sd, GeometricHodge()) * V_1; rtol = 1e-12))
         end
     end
 
@@ -226,8 +226,8 @@ end
     for sd in dual_meshes_1D
         V_1, V_2 = rand(nv(sd)), rand(nv(sd))
         E_1 = rand(ne(sd))
-        @test all(dec_wedge_product(Tuple{0, 0}, sd)(V_1, V_2) .== ∧(Tuple{0, 0}, sd, V_1, V_2))
-        @test all(isapprox.(dec_wedge_product(Tuple{0, 1}, sd)(V_1, E_1), ∧(Tuple{0, 1}, sd, V_1, E_1); atol=1e-15))
+        @test all(dec_wedge_product(0, 0, sd)(V_1, V_2) .== ∧(0, 0, sd, V_1, V_2))
+        @test all(isapprox.(dec_wedge_product(0, 1, sd)(V_1, E_1), ∧(0, 1, sd, V_1, E_1); atol=1e-15))
     end
 
     for sd in dual_meshes_2D
@@ -236,15 +236,15 @@ end
         T_2 = rand(ntriangles(sd))
         V_ones = ones(nv(sd))
         E_ones = ones(ne(sd))
-        @test all(dec_wedge_product(Tuple{0, 0}, sd)(V_1, V_2) .== ∧(Tuple{0, 0}, sd, V_1, V_2))
+        @test all(dec_wedge_product(0, 0, sd)(V_1, V_2) .== ∧(0, 0, sd, V_1, V_2))
 
-        wdg01 = dec_wedge_product(Tuple{0, 1}, sd)
-        @test all(isapprox.(wdg01(V_1, E_2), ∧(Tuple{0, 1}, sd, V_1, E_2); rtol = 1e-14))
+        wdg01 = dec_wedge_product(0, 1, sd)
+        @test all(isapprox.(wdg01(V_1, E_2), ∧(0, 1, sd, V_1, E_2); rtol = 1e-14))
         @test all(wdg01(V_ones, E_ones) .== E_ones)
 
-        @test all(dec_wedge_product(Tuple{0, 2}, sd)(V_1, T_2) .== ∧(Tuple{0, 2}, sd, V_1, T_2))
+        @test all(dec_wedge_product(0, 2, sd)(V_1, T_2) .== ∧(0, 2, sd, V_1, T_2))
 
-        @test all(dec_wedge_product(Tuple{1, 1}, sd)(E_1, E_2) .≈ ∧(Tuple{1, 1}, sd, E_1, E_2))
+        @test all(dec_wedge_product(1, 1, sd)(E_1, E_2) .≈ ∧(1, 1, sd, E_1, E_2))
     end
 
     for sd in dual_meshes_3D
@@ -257,27 +257,27 @@ end
         T_ones = ones(ntriangles(sd))
         Tet_ones = ones(ntetrahedra(sd))
 
-        wdg00 = dec_wedge_product(Tuple{0, 0}, sd)
-        wdg01 = dec_wedge_product(Tuple{0, 1}, sd)
-        wdg02 = dec_wedge_product(Tuple{0, 2}, sd)
-        wdg03 = dec_wedge_product(Tuple{0, 3}, sd)
+        wdg00 = dec_wedge_product(0, 0, sd)
+        wdg01 = dec_wedge_product(0, 1, sd)
+        wdg02 = dec_wedge_product(0, 2, sd)
+        wdg03 = dec_wedge_product(0, 3, sd)
 
-        wdg11 = dec_wedge_product(Tuple{1, 1}, sd)
-        wdg12 = dec_wedge_product(Tuple{1, 2}, sd)
+        wdg11 = dec_wedge_product(1, 1, sd)
+        wdg12 = dec_wedge_product(1, 2, sd)
 
         @test all(wdg00(V_ones, V_ones) .== V_ones)
         @test all(wdg01(V_ones, E_ones) .== E_ones)
         @test all(wdg02(V_ones, T_ones) .≈ T_ones)
         @test all(wdg03(V_ones, Tet_ones) .≈ Tet_ones)
         @test all(wdg11(E_ones, E_ones) .== zeros(ntriangles(sd)))
-        @test all(wdg12(E_ones, T_ones) .≈ ∧(Tuple{1,2}, sd, E_ones, T_ones))
+        @test all(wdg12(E_ones, T_ones) .≈ ∧(1, 2, sd, E_ones, T_ones))
 
-        @test all(wdg00(V_1, V_2) .≈ ∧(Tuple{0, 0}, sd, V_1, V_2))
-        @test all(wdg01(V_1, E_2) .≈ ∧(Tuple{0, 1}, sd, V_1, E_2))
-        @test all(wdg02(V_1, T_2) .≈ ∧(Tuple{0, 2}, sd, V_1, T_2))
-        @test all(wdg03(V_1, Tet_2) .≈ ∧(Tuple{0, 3}, sd, V_1, Tet_2))
-        @test all(wdg11(E_1, E_2) .≈ ∧(Tuple{1, 1}, sd, E_1, E_2))
-        @test all(wdg12(E_1, T_2) .≈ ∧(Tuple{1, 2}, sd, E_1, T_2))
+        @test all(wdg00(V_1, V_2) .≈ ∧(0, 0, sd, V_1, V_2))
+        @test all(wdg01(V_1, E_2) .≈ ∧(0, 1, sd, V_1, E_2))
+        @test all(wdg02(V_1, T_2) .≈ ∧(0, 2, sd, V_1, T_2))
+        @test all(wdg03(V_1, Tet_2) .≈ ∧(0, 3, sd, V_1, Tet_2))
+        @test all(wdg11(E_1, E_2) .≈ ∧(1, 1, sd, E_1, E_2))
+        @test all(wdg12(E_1, T_2) .≈ ∧(1, 2, sd, E_1, T_2))
     end
 
     # Test flipped edge orientation preserves value
@@ -285,9 +285,9 @@ end
     E_1, E_2 = rand(ne(sd)), rand(ne(sd))
     for i in 1:ne(sd)
         sd[i, :edge_orientation] = !sd[i, :edge_orientation]
-        wdg_11 = dec_wedge_product(Tuple{1, 1}, sd)
+        wdg_11 = dec_wedge_product(1, 1, sd)
         E_1[i] = -E_1[i]; E_2[i] = -E_2[i];
-        @test all(wdg_11(E_1, E_2) .≈ ∧(Tuple{1, 1}, sd, E_1, E_2))
+        @test all(wdg_11(E_1, E_2) .≈ ∧(1, 1, sd, E_1, E_2))
     end
 
     # Test flipped edge/tri orientation preserves value
@@ -296,9 +296,9 @@ end
     for (i,j) in zip(edges(sd), triangles(sd))
         sd[i, :edge_orientation] = !sd[i, :edge_orientation]
         sd[i, :tri_orientation] = !sd[i, :tri_orientation]
-        wdg_12 = dec_wedge_product(Tuple{1, 2}, sd)
+        wdg_12 = dec_wedge_product(1, 2, sd)
         E_1[i] = -E_1[i]; T_2[j] = -T_2[j];
-        @test all(wdg_12(E_1, T_2) .≈ ∧(Tuple{1, 2}, sd, E_1, T_2))
+        @test all(wdg_12(E_1, T_2) .≈ ∧(1, 2, sd, E_1, T_2))
     end
 end
 
@@ -312,7 +312,7 @@ end
   add_edges!(primal_line, 1:399, 2:400)
   sd = generate_dual_mesh(primal_line)
   twoX = map(p -> 2*p[1], sd[sd[:edge_center], :dual_point])
-  nil = Δᵈ(Val{0}, sd)(twoX)
+  nil = Δᵈ(Val(0), sd)(twoX)
   @test all(abs.(nil[begin+1:end-1]) .< 2e-11)
 
   # 2D
@@ -320,8 +320,8 @@ end
   # TODO: The issue might arise from a numerically singular Geometric Hodge
   for sd in [tg, rect]
     twoX = map(p -> 2*p[1], sd[sd[:tri_center], :dual_point])
-    nil = Δᵈ(Val{0}, sd)(twoX)
-    interior_tris = setdiff(triangles(sd), boundary_inds(Val{2}, sd))
+    nil = Δᵈ(Val(0), sd)(twoX)
+    interior_tris = setdiff(triangles(sd), boundary_inds(Val(2), sd))
     @test_broken abs(mean(nil[interior_tris])) < 1e-13
     @test_broken std(nil[interior_tris]) < 1e-13
   end
@@ -330,8 +330,8 @@ end
   # TODO: Investigate this operator as well, although it uses DiagonalHodge
   sd = tet_msh_sd
   twoX = map(p -> 2*p[1], sd[sd[:tet_center], :dual_point])
-  nil = Δᵈ(Val{0}, sd)(twoX)
-  interior_tets = setdiff(tetrahedra(sd), boundary_inds(Val{3}, sd))
+  nil = Δᵈ(Val(0), sd)(twoX)
+  interior_tets = setdiff(tetrahedra(sd), boundary_inds(Val(3), sd))
   @test abs(mean(nil[interior_tets])) < 0.03
   @test std(nil[interior_tets]) < 6.7
 end
@@ -341,7 +341,7 @@ end
         # Test that the averaging matrix can compute a wedge product.
         V_1 = rand(nv(sd))
         E_1 = rand(ne(sd))
-        expected_wedge = dec_wedge_product(Tuple{0, 1}, sd)(V_1, E_1)
+        expected_wedge = dec_wedge_product(0, 1, sd)(V_1, E_1)
         avg_mat = avg₀₁_mat(sd)
         @test all(expected_wedge .== (avg_mat * V_1 .* E_1))
         @test all(expected_wedge .== (avg₀₁(sd, VForm(V_1)) .* E_1))
@@ -351,7 +351,7 @@ end
         # Test that the averaging matrix can compute a wedge product.
         V_1 = rand(nv(sd))
         E_1 = rand(ne(sd))
-        expected_wedge = dec_wedge_product(Tuple{0, 1}, sd)(V_1, E_1)
+        expected_wedge = dec_wedge_product(0, 1, sd)(V_1, E_1)
         avg_mat = avg₀₁_mat(sd)
         @test all(expected_wedge .== (avg_mat * V_1 .* E_1))
         @test all(expected_wedge .== (avg₀₁(sd, VForm(V_1)) .* E_1))
@@ -361,8 +361,8 @@ end
 @testset "Primal-Dual Wedge Product 0-1" begin
     for sd in flat_meshes
       # Allocate the cached wedge operator.
-      Λ10 = dec_wedge_product_dp(Tuple{1,0}, sd)
-      Λ01 = dec_wedge_product_pd(Tuple{0,1}, sd)
+      Λ10 = dec_wedge_product_dp(1, 0, sd)
+      Λ01 = dec_wedge_product_pd(0, 1, sd)
       ♯_m = ♯_mat(sd, LLSDDSharp())
 
       # Define test data
@@ -384,11 +384,11 @@ end
       # numerical solution assumes values past the boundary are 0, whereas the
       # analytic solution has no such artifacting.  i.e. The numerical solution
       # does not hold on boundary edges.
-      interior_edges = setdiff(edges(sd), boundary_inds(Val{1}, sd))
+      interior_edges = setdiff(edges(sd), boundary_inds(Val(1), sd))
       length(interior_edges) == 0 && continue
 
       # Allocate the cached wedge operator.
-      Λ10 = dec_wedge_product_dp(Tuple{1,0}, sd)
+      Λ10 = dec_wedge_product_dp(1, 0, sd)
       ♯_m = ♯_mat(sd, LLSDDSharp())
       # Define test data and the analytic solution.
       a = map(point(sd)) do p
@@ -403,7 +403,7 @@ end
       end
       dx = eval_constant_primal_form(sd, SVector{3,Float64}(1,0,0))
       dy = eval_constant_primal_form(sd, SVector{3,Float64}(0,1,0))
-      fΛa_analytic = hodge_star(1,sd) * (-dec_wedge_product(Tuple{0,1}, sd)(h, dx) .+ dec_wedge_product(Tuple{0,1}, sd)(g, dy))
+      fΛa_analytic = hodge_star(1,sd) * (-dec_wedge_product(0, 1, sd)(h, dx) .+ dec_wedge_product(0, 1, sd)(g, dy))
 
       # a := x + 4y
       # f := ⋆da
@@ -420,8 +420,8 @@ end
 @testset "Dual-Dual Wedge Product 0-1" begin
     for sd in flat_meshes
       # Allocate the cached wedge operator.
-      Λ10 = dec_wedge_product_dd(Tuple{1,0}, sd)
-      Λ01 = dec_wedge_product_dd(Tuple{0,1}, sd)
+      Λ10 = dec_wedge_product_dd(1, 0, sd)
+      Λ01 = dec_wedge_product_dd(0, 1, sd)
 
       # Define test data
       X♯ = SVector{3,Float64}(1/√2,1/√2,0)
@@ -441,11 +441,11 @@ end
 
 @testset "Interior Product Dual-Dual 1-1" begin
     for sd in flat_meshes
-      interior_edges = setdiff(edges(sd), boundary_inds(Val{1}, sd))
+      interior_edges = setdiff(edges(sd), boundary_inds(Val(1), sd))
       isempty(interior_edges) && continue
       # Allocate the cached operators.
       d0 = dec_dual_derivative(0, sd)
-      ι1 = interior_product_dd(Tuple{1,1}, sd)
+      ι1 = interior_product_dd(1, 1, sd)
 
       # Define test data
       X♯ = SVector{3,Float64}(1/√2,1/√2,0)
@@ -472,16 +472,16 @@ function plot_dual0form(sd, f0)
 end
 
 function euler_equation_test(X♯, sd)
-  interior_tris = setdiff(triangles(sd), boundary_inds(Val{2}, sd))
+  interior_tris = setdiff(triangles(sd), boundary_inds(Val(2), sd))
 
   # Allocate the cached operators.
   d0 = dec_dual_derivative(0, sd)
   d1 = dec_differential(1, sd);
   s1 = dec_hodge_star(1, sd);
   s2 = dec_hodge_star(2, sd);
-  ι1 = interior_product_dd(Tuple{1,1}, sd)
-  ι2 = interior_product_dd(Tuple{1,2}, sd)
-  ℒ1 = ℒ_dd(Tuple{1,1}, sd)
+  ι1 = interior_product_dd(1, 1, sd)
+  ι2 = interior_product_dd(1, 2, sd)
+  ℒ1 = ℒ_dd(1, 1, sd)
 
   # This is a uniform, constant flow.
   u = s1 * eval_constant_primal_form(sd, X♯)
@@ -546,9 +546,9 @@ end
     p[1]
   end
   dx = eval_constant_primal_form(sd, SVector{3,Float64}(1,0,0))
-  u = hodge_star(1,sd) * dec_wedge_product(Tuple{0,1}, sd)(f, dx)
-  ι1 = interior_product_dd(Tuple{1,1}, sd)
-  interior_tris = setdiff(triangles(sd), boundary_inds(Val{2}, sd))
+  u = hodge_star(1,sd) * dec_wedge_product(0, 1, sd)(f, dx)
+  ι1 = interior_product_dd(1, 1, sd)
+  interior_tris = setdiff(triangles(sd), boundary_inds(Val(2), sd))
   @test all(<(8e-3), (ι1(u,u) .- map(sd[sd[:tri_center], :dual_point]) do (x,_,_)
     x*x
   end)[interior_tris])

--- a/test/SimplicialSets.jl
+++ b/test/SimplicialSets.jl
@@ -75,12 +75,6 @@ s = OrientedDeltaSet1D{Bool}()
 add_vertices!(s, 10)
 add_edges!(s, 1:4, 2:5)
 add_edges!(s, 6:9, 7:10)
-@test orient_component!(s, 1, true)
-@test orientation(s, E(1:4)) == trues(4)
-@test orient_component!(s, 8, true)
-@test orientation(s, E(1:8)) == trues(8)
-
-s[:edge_orientation] = rand(Bool, 8)
 @test orient!(s)
 @test orientation(s, E(1:8)) == trues(8)
 
@@ -127,7 +121,7 @@ s = OrientedDeltaSet2D{Bool}()
 add_vertices!(s, 3)
 add_sorted_edges!(s, [1,2,3], [2,3,1], edge_orientation=[true,true,false])
 glue_triangle!(s, 1, 2, 3)
-@test orient_component!(s, 1, true)
+@test orient!(s)
 @test orientation(s, Tri(1)) == true
 @test ∂(2, s, 1) == [1,1,1]
 @test d(1, s, [45,3,34]) == [82]
@@ -246,7 +240,7 @@ add_vertices!(s, 4)
 glue_tetrahedron!(s, 1, 2, 3, 4)
 s[:edge_orientation] = [true, false, true, false, true, false]
 s[:tri_orientation] = [true, false, true, false]
-@test orient_component!(s, 1, true)
+@test orient!(s)
 @test orientation(s, Tet(1)) == true
 @test ∂(3, s, 1) == [1,1,1,1]
 @test ∂(2, s, 1) == [1,-1,-1,0,0,0]
@@ -576,13 +570,13 @@ s = cycle_graph(DeltaSet1D, 8)
 ##################################
 # Line:
 s = path_graph(DeltaSet1D, 8)
-bvs, bes = boundary_inds(Val{0}, s), boundary_inds(Val{1}, s)
+bvs, bes = boundary_inds(Val(0), s), boundary_inds(Val(1), s)
 @test issetequal(bvs, [1,8])
 @test issetequal(bes, [1,7])
 
 # Circle:
 s = cycle_graph(DeltaSet1D, 8)
-bvs, bes = boundary_inds(Val{0}, s), boundary_inds(Val{1}, s)
+bvs, bes = boundary_inds(Val(0), s), boundary_inds(Val(1), s)
 @test issetequal(bvs, [])
 @test issetequal(bes, [])
 
@@ -590,7 +584,7 @@ bvs, bes = boundary_inds(Val{0}, s), boundary_inds(Val{1}, s)
 s = path_graph(DeltaSet1D, 8)
 const 𝒞 = ACSetCategory(CSetCat(DeltaSet1D()))
 s = apex(coproduct[𝒞](s,s))
-bvs, bes = boundary_inds(Val{0}, s), boundary_inds(Val{1}, s)
+bvs, bes = boundary_inds(Val(0), s), boundary_inds(Val(1), s)
 @test issetequal(bvs, [1,8,9,16])
 @test issetequal(bes, [1,7,8,14])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,6 @@
 module RunTests
 using Test
 
-@testset "Multigrid" begin
-  include("Multigrid.jl")
-end
-
 @testset "CombinatorialMaps" begin
   include("CombinatorialMaps.jl")
 end
@@ -35,6 +31,10 @@ end
 
 @testset "Mesh Optimization" begin
   include("MeshOptimization.jl")
+end
+
+@testset "Multigrid" begin
+  include("Multigrid.jl")
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 module RunTests
 using Test
 
+@testset "Multigrid" begin
+  include("Multigrid.jl")
+end
+
 @testset "CombinatorialMaps" begin
   include("CombinatorialMaps.jl")
 end
@@ -27,10 +31,6 @@ end
 
 @testset "Restrictions" begin
   include("Restrictions.jl")
-end
-
-@testset "Multigrid" begin
-  include("Multigrid.jl")
 end
 
 @testset "Mesh Optimization" begin


### PR DESCRIPTION
Currently, we allocate the data needed for multigrid by explicitly creating a diagram in the category of geometric maps $$GM$$ and then we compute the restriction and prolongation operators from this. That is, we store all meshes in the series concurrently. Also, we compute the operators for each mesh by calling the constructor repeatedly, which in turn necessitates computing all dual meshes.

However, these methods have high memory requirements.

So, this PR introduces a constructor that creates a `MultigridData` struct directly, without allocating a `PrimalGeometricMapSeries`. (The diagram in $$GM$$ is traversed one morphism at a time.) This is a modest performance optimization for most workflows, but can be very impactful for the garbage collector when total available memory is an issue.

This PR also performs the so-called Galerkin optimization by calling the given constructor once on the finest mesh. This provides a much more robust improvement in time and memory. The resulting solvers sacrifice about 1 digit in the residuals on random solves.

This is related to [Decapodes PR 344](https://github.com/AlgebraicJulia/Decapodes.jl/pull/344).